### PR TITLE
Fix startup defaults

### DIFF
--- a/teos/src/conf_template.toml
+++ b/teos/src/conf_template.toml
@@ -11,7 +11,7 @@ btc_network = "bitcoin"
 btc_rpc_user = "CSW"
 btc_rpc_password = "NotSatoshi"
 btc_rpc_connect = "localhost"
-btc_rpc_port = 8442
+btc_rpc_port = 8332
 
 # Flags
 debug = false

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -203,10 +203,10 @@ impl Config {
                 // overwritten at this point.
                 if self.btc_rpc_port == 0 {
                     self.btc_rpc_port = match network {
-                        Network::Testnet => 18333,
-                        Network::Signet => 38333,
+                        Network::Testnet => 18332,
+                        Network::Signet => 38332,
                         Network::Regtest => 18443,
-                        _ => 8442,
+                        _ => 8332,
                     }
                 }
                 Ok(())

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -1,5 +1,6 @@
 use simple_logger::init_with_level;
 use std::fs;
+use std::io::ErrorKind;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::sync::{Arc, Condvar, Mutex};
@@ -129,7 +130,11 @@ async fn main() {
             Arc::new((Mutex::new(true), Condvar::new())),
         ),
         Err(e) => {
-            log::error!("Failed to connect to bitcoind client: {}", e);
+            let e_msg = match e.kind() {
+                ErrorKind::InvalidData => "invalid btcrpcuser or btcrpcpassword".into(),
+                _ => e.to_string(),
+            };
+            log::error!("Failed to connect to bitcoind. Error: {}", e_msg);
             return;
         }
     };


### PR DESCRIPTION
The default rpc ports for mainnet, testnet and signet were wrong. Set the up correctly.

Furthermore, return a more friendly error message when the rpc username or password is incorrect.