### PR TITLE
feat: `get_appointments` cli command

### DIFF
--- a/teos/proto/teos/appointment.proto
+++ b/teos/proto/teos/appointment.proto
@@ -74,6 +74,18 @@ message GetAppointmentResponse {
   AppointmentStatus status = 2;
 }
 
+message GetAppointmentsRequest {
+  // Request the information of appointments with specific locator.
+
+  bytes locator = 1;
+}
+
+message GetAppointmentsResponse {
+  // Response with the information of all appointments with a specific locator.
+
+  repeated AppointmentData appointments = 1;
+}
+
 message GetAllAppointmentsResponse {
   // Response with data about all the appointments in the tower. 
   

--- a/teos/proto/teos/tower_services.proto
+++ b/teos/proto/teos/tower_services.proto
@@ -28,6 +28,7 @@ service PrivateTowerServices {
   // Private tower services, only reachable from the private API.
 
   rpc get_all_appointments(google.protobuf.Empty) returns (GetAllAppointmentsResponse) {}
+  rpc get_appointments(GetAppointmentsRequest) returns (GetAppointmentsResponse) {}
   rpc get_tower_info(google.protobuf.Empty) returns (GetTowerInfoResponse) {}
   rpc get_users(google.protobuf.Empty) returns (GetUsersResponse) {}
   rpc get_user(GetUserRequest) returns (GetUserResponse) {}

--- a/teos/src/cli_config.rs
+++ b/teos/src/cli_config.rs
@@ -8,6 +8,8 @@ use structopt::StructOpt;
 pub enum Command {
     /// Gets information about all appointments stored in the tower
     GetAllAppointments,
+    /// Gets information about specific appointments stored in the tower using a locator
+    GetAppointments(GetAppointmentsData),
     /// Gets generic information about the tower, like tower id and aggregate data on users and appointments
     GetTowerInfo,
     /// Gets an array with the user ids of all the users registered to the tower
@@ -23,6 +25,12 @@ pub enum Command {
 pub struct GetUserData {
     /// The user identifier (33-byte compressed public key).
     pub user_id: String,
+}
+
+#[derive(Debug, StructOpt, Clone)]
+pub struct GetAppointmentsData {
+    /// The locator of the appointments (16-byte hexadecimal string).
+    pub locator: String,
 }
 
 /// Holds all the command line options and commands.

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -269,7 +269,7 @@ impl Watcher {
     ) -> Self {
         let mut appointments = HashMap::new();
         let mut locator_uuid_map: HashMap<Locator, HashSet<UUID>> = HashMap::new();
-        for (uuid, appointment) in dbm.lock().unwrap().load_all_appointments() {
+        for (uuid, appointment) in dbm.lock().unwrap().load_appointments(None) {
             appointments.insert(uuid, appointment.get_summary());
 
             if let Some(map) = locator_uuid_map.get_mut(&appointment.locator()) {
@@ -702,12 +702,28 @@ impl Watcher {
 
     /// Gets all the appointments stored in the [Watcher] (from the database).
     pub(crate) fn get_all_watcher_appointments(&self) -> HashMap<UUID, ExtendedAppointment> {
-        self.dbm.lock().unwrap().load_all_appointments()
+        self.dbm.lock().unwrap().load_appointments(None)
+    }
+
+    /// Gets all the appointments matching a specific locator from the [Watcher] (from the database).
+    pub(crate) fn get_watcher_appointments_with_locator(
+        &self,
+        locator: Locator,
+    ) -> HashMap<UUID, ExtendedAppointment> {
+        self.dbm.lock().unwrap().load_appointments(Some(locator))
     }
 
     /// Gets all the trackers stored in the [Responder] (from the database).
     pub(crate) fn get_all_responder_trackers(&self) -> HashMap<UUID, TransactionTracker> {
-        self.dbm.lock().unwrap().load_all_trackers()
+        self.dbm.lock().unwrap().load_trackers(None)
+    }
+
+    /// Gets all the trackers matching s specific locator from the [Responder] (from the database).
+    pub(crate) fn get_responder_trackers_with_locator(
+        &self,
+        locator: Locator,
+    ) -> HashMap<UUID, TransactionTracker> {
+        self.dbm.lock().unwrap().load_trackers(Some(locator))
     }
 
     /// Gets the list of all registered user ids.
@@ -896,10 +912,18 @@ mod tests {
     impl Eq for Watcher {}
 
     impl Watcher {
-        pub(crate) fn add_random_tracker_to_responder(&self, uuid: UUID) {
+        pub(crate) fn add_dummy_tracker_to_responder(
+            &self,
+            uuid: UUID,
+            tracker: &TransactionTracker,
+        ) {
+            self.responder.add_dummy_tracker(uuid, tracker)
+        }
+
+        pub(crate) fn add_random_tracker_to_responder(&self, uuid: UUID) -> TransactionTracker {
             // The confirmation status can be whatever here. Using the most common.
             self.responder
-                .add_random_tracker(uuid, ConfirmationStatus::ConfirmedIn(100));
+                .add_random_tracker(uuid, ConfirmationStatus::ConfirmedIn(100))
         }
     }
 


### PR DESCRIPTION
This PR adds a new command `get_appointments` to `teos-cli`.

A big chunk of `load_appointments_with_locator` and `load_trackers_with_locator` is repeated in `load_all_appointments` and `load_all_trackers` respectively, Should common parts be put together in new functions?

Closes #40 