### PR TITLE
Tor endpoint http api

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ For regtest, it should look like:
 btc_network = regtest
 ```
 
+### Running TEOS with tor
+
+This requires a tor deamon running on the same machine as teos and a control port open on that deamon.
+
+Download tor from the torproject site here: [torproject](https://www.torproject.org/download/)
+
+To open tor's control port, follow the instructions here on how to update the configuration file [tor conf](https://2019.www.torproject.org/docs/faq.html.en#torrc)
+
+Add the following lines to the file:
+```
+## The port on which Tor will listen for local connections from Tor
+## controller applications, as documented in control-spec.txt.
+ControlPort 9051
+
+## If you enable the controlport, be sure to enable one of these
+## authentication methods, to prevent attackers from accessing it.
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+```
+
+Once the tor deamon is running, and the control port is open, make sure to change `tor_support` flag to true in teos conf.
+
 ### Tower id and signing key
 
 `teos` needs a pair of keys that will serve as tower id and signing key. The former can be used by users to identify the tower, whereas the latter is used by the tower to sign responses. These keys are automatically generated on the first run, and can be refreshed by running `teos` with the `--overwritekey` flag. Notice that once a key is overwritten you won't be able to use the previous key again*.

--- a/teos/Cargo.toml
+++ b/teos/Cargo.toml
@@ -30,6 +30,7 @@ tonic = "0.6"
 tokio = { version = "1.5", features = [ "rt-multi-thread" ] }
 triggered = "0.1.2"
 warp = "0.3.2"
+torut = "0.2.1"
 
 # Bitcoin and Lightning
 bitcoin = { version = "0.27", features = [ "base64" ] }

--- a/teos/src/api/mod.rs
+++ b/teos/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod http;
 pub mod internal;
+pub mod tor;
 
 pub mod serde_status {
     use serde::de::{self, Deserializer};

--- a/teos/src/api/tor.rs
+++ b/teos/src/api/tor.rs
@@ -1,0 +1,118 @@
+use std::io::{Error, ErrorKind};
+use std::net::SocketAddr;
+use tokio::net::TcpStream;
+use tokio::time::{sleep, Duration};
+use torut::control::UnauthenticatedConn;
+use torut::onion::TorSecretKeyV3;
+use triggered::Listener;
+
+/// Expose an onion service that re-directs to the public api.
+pub async fn expose_onion_service(
+    tor_control_port: u16,
+    api_port: u16,
+    onion_port: u16,
+    shutdown_signal_tor: Listener,
+) -> Result<(), Error> {
+    let stream = connect_tor_cp(format!("127.0.0.1:{}", tor_control_port).parse().unwrap())
+        .await
+        .map_err(|e| Error::new(ErrorKind::ConnectionRefused, e))?;
+
+    let mut unauth_conn = UnauthenticatedConn::new(stream);
+
+    let pre_auth = unauth_conn
+        .load_protocol_info()
+        .await
+        .map_err(|e| Error::new(ErrorKind::ConnectionRefused, e))?;
+
+    let auth_data = pre_auth
+        .make_auth_data()?
+        .expect("failed to make auth data");
+
+    unauth_conn.authenticate(&auth_data).await.map_err(|_| {
+        Error::new(
+            ErrorKind::PermissionDenied,
+            "failed to authenticate with Tor",
+        )
+    })?;
+
+    let mut auth_conn = unauth_conn.into_authenticated().await;
+
+    auth_conn.set_async_event_handler(Some(|_| async move { Ok(()) }));
+
+    let key = TorSecretKeyV3::generate();
+
+    auth_conn
+        .add_onion_v3(
+            &key,
+            false,
+            false,
+            false,
+            None,
+            &mut [(
+                onion_port,
+                format!("127.0.0.1:{}", api_port).parse().unwrap(),
+            )]
+            .iter(),
+        )
+        .await
+        .map_err(|e| {
+            Error::new(
+                ErrorKind::Other,
+                format!("failed to create onion hidden service: {}", e),
+            )
+        })?;
+
+    print_onion_service(key.clone(), onion_port);
+
+    // NOTE: Needed to keep connection with control port & hidden service running, as soon as we leave
+    // this function the control port stream is dropped and the hidden service is killed
+    loop {
+        sleep(Duration::from_secs(1)).await;
+        if shutdown_signal_tor.is_triggered() {
+            break;
+        }
+    }
+
+    auth_conn
+        .del_onion(
+            &key.public()
+                .get_onion_address()
+                .get_address_without_dot_onion(),
+        )
+        .await
+        .unwrap();
+    Ok(())
+}
+
+async fn connect_tor_cp(addr: SocketAddr) -> Result<TcpStream, Error> {
+    let sock = TcpStream::connect(addr).await.map_err(|_| {
+        Error::new(
+            ErrorKind::ConnectionRefused,
+            "failed to connect to tor control port",
+        )
+    })?;
+    Ok(sock)
+}
+
+fn print_onion_service(key: TorSecretKeyV3, onion_port: u16) {
+    let onion_addr = key.public().get_onion_address();
+    let onion = format!("{}:{}", onion_addr, onion_port);
+    log::info!("onion service: {}", onion);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_connect_tor_cp_fail() {
+        let tor_control_port = 9000;
+        let addr = format!("127.0.0.1:{}", tor_control_port).parse().unwrap();
+        match connect_tor_cp(addr).await {
+            Ok(_) => {}
+            Err(e) => {
+                assert_eq!("failed to connect to tor control port", e.to_string())
+            }
+        }
+    }
+}

--- a/teos/src/conf_template.toml
+++ b/teos/src/conf_template.toml
@@ -1,6 +1,9 @@
 # API
 api_bind = "127.0.0.1"
 api_port = 9814
+tor_control_port = 9051
+onion_hidden_service_port = 2121
+tor_support = false
 
 # RPC
 rpc_bind = "127.0.0.1"


### PR DESCRIPTION
Added a new file 'tor.rs' to the 'api' folder which uses the torut library to create an onion hidden service. It accomplishes this by calling out to a running tor daemon, on the same machine, through it's control port. I added a dependency to the 'anyhow' library, if we'd rather not added that, just let me know and I can figure out how to pull that library out from my changes. I added some basic unit tests, but if you believe this needs more coverage, again, just let me know. Personally think adding more testing to the tor.rs file will really just be unit testing the torut library more than my code. I have attached the command I used to get a successful response when running this code as well:
![toes-command](https://user-images.githubusercontent.com/95582269/164944824-cafa833f-22d8-48c2-ae2d-961ddf589abb.png)
![success_response](https://user-images.githubusercontent.com/95582269/164944826-3a550aa5-62c9-4df8-ba9b-bebb7d2aadbf.png)
