### PR TITLE
Revert to old tower keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ btc_network = regtest
 
 ### Tower id and signing key
 
-`teos` needs a pair of keys that will serve as tower id and signing key. The former can be used by users to identify the tower, whereas the latter is used by the tower to sign responses. These keys are automatically generated on the first run, and can be refreshed by running `teos` with the `--usenewkey` flag.
+`teos` needs a pair of keys that will serve as tower id and signing key. The former can be used by users to identify the tower, whereas the latter is used by the tower to sign responses. These keys are automatically generated on the first run, and can be refreshed by running `teos` with the `--generatenewkey` flag.
 
-You can use an old key with the `--usekey <keyindex>` option, where `keyindex` is the index of the desired secret key. The first tower secret key will have `keyindex` equal to `1` and subsequent keys will have their `keyindex` auto-incremented.
+You can use an old key with the `--towerkey <keyindex>` option, where `keyindex` is the index of the desired secret key. The first tower secret key will have `keyindex` equal to `1` and subsequent keys will have their `keyindex` auto-incremented.
 
 ## Interacting with a TEOS Instance
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ btc_network = regtest
 
 ### Tower id and signing key
 
-`teos` needs a pair of keys that will serve as tower id and signing key. The former can be used by users to identify the tower, whereas the latter is used by the tower to sign responses. These keys are automatically generated on the first run, and can be refreshed by running `teos` with the `--overwritekey` flag. Notice that once a key is overwritten you won't be able to use the previous key again*.
+`teos` needs a pair of keys that will serve as tower id and signing key. The former can be used by users to identify the tower, whereas the latter is used by the tower to sign responses. These keys are automatically generated on the first run, and can be refreshed by running `teos` with the `--usenewkey` flag.
 
-\* Old keys are actually kept in the tower's database as a fail safe in case you overwrite them by mistake. However, there is no automated way of switching back to and old key. Feel free to open an issue if you overwrote your key by mistake and need support to recover it.
+You can use an old key with the `--usekey <keyindex>` option, where `keyindex` is the index of the desired secret key. The first tower secret key will have `keyindex` equal to `1` and subsequent keys will have their `keyindex` auto-incremented.
 
 ## Interacting with a TEOS Instance
 

--- a/teos/src/conf_template.toml
+++ b/teos/src/conf_template.toml
@@ -15,7 +15,7 @@ btc_rpc_port = 8332
 
 # Flags
 debug = false
-use_new_key = false
+generate_new_key = false
 
 # General
 subscription_slots = 10000

--- a/teos/src/conf_template.toml
+++ b/teos/src/conf_template.toml
@@ -15,7 +15,7 @@ btc_rpc_port = 8332
 
 # Flags
 debug = false
-overwrite_key = false
+use_new_key = false
 
 # General
 subscription_slots = 10000

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -103,14 +103,14 @@ pub struct Opt {
 
     /// Generates a new secret key for the tower. This will change your tower ID
     #[structopt(long)]
-    pub use_new_key: bool,
+    pub generate_new_key: bool,
 
     /// Index of the tower's secret key [default: None]
     ///
     /// keyindex is the index of the secret key starting from 1 and is auto-incremented with each new key used.
     /// Not specifying this option will let the tower choose the last known secret key.
-    #[structopt(long, conflicts_with = "usenewkey", name = "keyindex")]
-    pub use_key: Option<u32>,
+    #[structopt(long, conflicts_with = "generatenewkey", name = "keyindex")]
+    pub tower_key: Option<u32>,
 }
 
 /// Holds all configuration options.
@@ -139,10 +139,10 @@ pub struct Config {
 
     // Flags
     pub debug: bool,
-    pub use_new_key: bool,
+    pub generate_new_key: bool,
 
     // General
-    pub use_key: Option<u32>,
+    pub tower_key: Option<u32>,
     pub subscription_slots: u32,
     pub subscription_duration: u32,
     pub expiry_delta: u32,
@@ -186,8 +186,8 @@ impl Config {
         }
 
         self.debug |= options.debug;
-        self.use_new_key = options.use_new_key;
-        self.use_key = options.use_key;
+        self.generate_new_key = options.generate_new_key;
+        self.tower_key = options.tower_key;
     }
 
     /// Verifies that [Config] is properly built.
@@ -248,8 +248,8 @@ impl Default for Config {
             btc_rpc_port: 0,
 
             debug: false,
-            use_new_key: false,
-            use_key: None,
+            generate_new_key: false,
+            tower_key: None,
             subscription_slots: 10000,
             subscription_duration: 4320,
             expiry_delta: 6,
@@ -280,8 +280,8 @@ mod tests {
                 data_dir: String::from("~/.teos"),
 
                 debug: false,
-                use_new_key: false,
-                use_key: None,
+                generate_new_key: false,
+                tower_key: None,
             }
         }
     }

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -101,9 +101,16 @@ pub struct Opt {
     #[structopt(long)]
     pub debug: bool,
 
-    /// Overwrites the tower secret key. THIS IS IRREVERSIBLE AND WILL CHANGE YOUR TOWER ID
+    /// Generates a new secret key for the tower. This will change your tower ID
     #[structopt(long)]
-    pub overwrite_key: bool,
+    pub use_new_key: bool,
+
+    /// Index of the tower's secret key [default: None]
+    ///
+    /// keyindex is the index of the secret key starting from 1 and is auto-incremented with each new key used.
+    /// Not specifying this option will let the tower choose the last known secret key.
+    #[structopt(long, conflicts_with = "usenewkey", name = "keyindex")]
+    pub use_key: Option<u32>,
 }
 
 /// Holds all configuration options.
@@ -132,9 +139,10 @@ pub struct Config {
 
     // Flags
     pub debug: bool,
-    pub overwrite_key: bool,
+    pub use_new_key: bool,
 
     // General
+    pub use_key: Option<u32>,
     pub subscription_slots: u32,
     pub subscription_duration: u32,
     pub expiry_delta: u32,
@@ -178,7 +186,8 @@ impl Config {
         }
 
         self.debug |= options.debug;
-        self.overwrite_key = options.overwrite_key;
+        self.use_new_key = options.use_new_key;
+        self.use_key = options.use_key;
     }
 
     /// Verifies that [Config] is properly built.
@@ -239,7 +248,8 @@ impl Default for Config {
             btc_rpc_port: 0,
 
             debug: false,
-            overwrite_key: false,
+            use_new_key: false,
+            use_key: None,
             subscription_slots: 10000,
             subscription_duration: 4320,
             expiry_delta: 6,
@@ -270,7 +280,8 @@ mod tests {
                 data_dir: String::from("~/.teos"),
 
                 debug: false,
-                overwrite_key: false,
+                use_new_key: false,
+                use_key: None,
             }
         }
     }

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -97,19 +97,24 @@ async fn main() {
         DBM::new(path_network.join("teos_db.sql3")).unwrap(),
     ));
 
-    // Load tower secret key or create a fresh one if none is found. If overwrite key is set, create a new
+    // Load tower secret key or create a fresh one if none is found. If use_new_key is set, create a new
     // key straightaway
     let (tower_sk, tower_pk) = {
         let locked_db = dbm.lock().unwrap();
-        if conf.overwrite_key {
-            log::info!("Overwriting tower keys");
+        if conf.use_new_key {
+            log::info!("Generating new tower keys");
             create_new_tower_keypair(&locked_db)
         } else {
-            match locked_db.load_tower_key() {
+            match locked_db.load_tower_key(conf.use_key) {
                 Ok(sk) => (sk, PublicKey::from_secret_key(&Secp256k1::new(), &sk)),
                 Err(_) => {
-                    log::info!("Tower keys not found. Creating a fresh set");
-                    create_new_tower_keypair(&locked_db)
+                    if let Some(sk_index) = conf.use_key {
+                        eprintln!("No tower key of index {} found in the database.", sk_index);
+                        std::process::exit(1);
+                    } else {
+                        log::info!("Tower keys not found. Creating a fresh set");
+                        create_new_tower_keypair(&locked_db)
+                    }
                 }
             }
         }

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -97,19 +97,19 @@ async fn main() {
         DBM::new(path_network.join("teos_db.sql3")).unwrap(),
     ));
 
-    // Load tower secret key or create a fresh one if none is found. If use_new_key is set, create a new
+    // Load tower secret key or create a fresh one if none is found. If generate_new_key is set, create a new
     // key straightaway
     let (tower_sk, tower_pk) = {
         let locked_db = dbm.lock().unwrap();
-        if conf.use_new_key {
+        if conf.generate_new_key {
             log::info!("Generating new tower keys");
             create_new_tower_keypair(&locked_db)
         } else {
-            match locked_db.load_tower_key(conf.use_key) {
+            match locked_db.load_tower_key(conf.tower_key) {
                 Ok(sk) => (sk, PublicKey::from_secret_key(&Secp256k1::new(), &sk)),
                 Err(_) => {
-                    if let Some(sk_index) = conf.use_key {
-                        eprintln!("No tower key of index {} found in the database.", sk_index);
+                    if let Some(key_index) = conf.tower_key {
+                        eprintln!("No tower key of index {} found in the database.", key_index);
                         std::process::exit(1);
                     } else {
                         log::info!("Tower keys not found. Creating a fresh set");


### PR DESCRIPTION
## Changes:
- Renames `--overwritekey` flag to `--generatenewkey`.
- Adds a new option `--towerkey <keyindex>`, which allows the usage of old tower keys based on their indices (first key have index 0, second has 1, and so on).
- Makes the `dbm::DBM::load_tower_key()` method accept an optional key index to load.

Closes #49 