### PR TITLE
Uses serde functions from bitcoin crate in a consistent manner

### DIFF
--- a/teos/src/carrier.rs
+++ b/teos/src/carrier.rs
@@ -224,7 +224,7 @@ mod tests {
         get_random_tx, start_server, BitcoindMock, MockOptions, START_HEIGHT, TX_HEX,
     };
 
-    use bitcoin::consensus::deserialize;
+    use bitcoin::consensus;
     use bitcoin::hashes::hex::FromHex;
     use bitcoincore_rpc::Auth;
 
@@ -273,7 +273,7 @@ mod tests {
         start_server(bitcoind_mock);
 
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
-        let tx = deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
+        let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
         assert_eq!(r, ConfirmationStatus::InMempoolSince(start_height));
@@ -293,7 +293,7 @@ mod tests {
         start_server(bitcoind_mock);
 
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
-        let tx = deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
+        let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
         assert_eq!(
@@ -315,7 +315,7 @@ mod tests {
         start_server(bitcoind_mock);
 
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
-        let tx = deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
+        let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
         assert_eq!(
@@ -340,7 +340,7 @@ mod tests {
         start_server(bitcoind_mock);
 
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
-        let tx = deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
+        let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
         assert_eq!(r, ConfirmationStatus::ConfirmedIn(start_height));
@@ -359,7 +359,7 @@ mod tests {
         start_server(bitcoind_mock);
 
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
-        let tx = deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
+        let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
         assert_eq!(
@@ -380,7 +380,7 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable.clone(), start_height);
 
-        let tx = deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
+        let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let delay = std::time::Duration::new(3, 0);
 
         thread::spawn(move || {
@@ -411,7 +411,7 @@ mod tests {
         start_server(bitcoind_mock);
 
         let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
-        let tx = deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
+        let tx = consensus::deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         assert_eq!(
             carrier.get_tx_height(&tx.txid()),
             Some(target_height as u32)
@@ -429,7 +429,7 @@ mod tests {
         start_server(bitcoind_mock);
 
         let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
-        let tx = deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
+        let tx = consensus::deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         assert_eq!(carrier.get_tx_height(&tx.txid()), None);
     }
 
@@ -471,7 +471,7 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock);
 
-        let tx = deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
+        let tx = consensus::deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         assert_eq!(carrier.get_block_hash_for_tx(&tx.txid()), Some(block_hash));
     }
@@ -484,7 +484,7 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock);
 
-        let tx = deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
+        let tx = consensus::deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         assert_eq!(carrier.get_block_hash_for_tx(&tx.txid()), None);
     }

--- a/teos/src/dbm.rs
+++ b/teos/src/dbm.rs
@@ -9,11 +9,10 @@ use rusqlite::ffi::{SQLITE_CONSTRAINT_FOREIGNKEY, SQLITE_CONSTRAINT_PRIMARYKEY};
 use rusqlite::limits::Limit;
 use rusqlite::{params, params_from_iter, Connection, Error as SqliteError, ErrorCode, Params};
 
-use bitcoin::consensus::deserialize;
+use bitcoin::consensus;
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::SecretKey;
-use bitcoin::util::psbt::serialize::Serialize;
-use bitcoin::{BlockHash, Transaction};
+use bitcoin::BlockHash;
 
 use teos_common::appointment::{Appointment, Locator};
 use teos_common::constants::ENCRYPTED_BLOB_MAX_SIZE;
@@ -465,8 +464,8 @@ impl DBM {
             query,
             params![
                 uuid.serialize(),
-                tracker.dispute_tx.serialize(),
-                tracker.penalty_tx.serialize(),
+                consensus::serialize(&tracker.dispute_tx),
+                consensus::serialize(&tracker.penalty_tx),
                 height,
                 confirmed,
             ],
@@ -490,9 +489,9 @@ impl DBM {
 
         stmt.query_row([key], |row| {
             let raw_dispute_tx: Vec<u8> = row.get(1).unwrap();
-            let dispute_tx = deserialize::<Transaction>(&raw_dispute_tx).unwrap();
+            let dispute_tx = consensus::deserialize(&raw_dispute_tx).unwrap();
             let raw_penalty_tx: Vec<u8> = row.get(2).unwrap();
-            let penalty_tx = deserialize::<Transaction>(&raw_penalty_tx).unwrap();
+            let penalty_tx = consensus::deserialize(&raw_penalty_tx).unwrap();
             let height: u32 = row.get(3).unwrap();
             let confirmed: bool = row.get(4).unwrap();
             let raw_userid: Vec<u8> = row.get(5).unwrap();
@@ -521,9 +520,9 @@ impl DBM {
             let raw_uuid: Vec<u8> = row.get(0).unwrap();
             let uuid = UUID::deserialize(&raw_uuid[0..20]).unwrap();
             let raw_dispute_tx: Vec<u8> = row.get(1).unwrap();
-            let dispute_tx = deserialize::<Transaction>(&raw_dispute_tx).unwrap();
+            let dispute_tx = consensus::deserialize(&raw_dispute_tx).unwrap();
             let raw_penalty_tx: Vec<u8> = row.get(2).unwrap();
-            let penalty_tx = deserialize::<Transaction>(&raw_penalty_tx).unwrap();
+            let penalty_tx = consensus::deserialize(&raw_penalty_tx).unwrap();
             let height: u32 = row.get(3).unwrap();
             let confirmed: bool = row.get(4).unwrap();
             let raw_userid: Vec<u8> = row.get(5).unwrap();

--- a/teos/src/responder.rs
+++ b/teos/src/responder.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::sync::{Arc, Mutex};
 
-use bitcoin::util::psbt::serialize::Serialize;
+use bitcoin::consensus;
 use bitcoin::{BlockHeader, Transaction, Txid};
 use lightning::chain;
 
@@ -113,7 +113,7 @@ impl From<TransactionTracker> for msgs::Tracker {
         msgs::Tracker {
             dispute_txid: t.dispute_tx.txid().to_vec(),
             penalty_txid: t.penalty_tx.txid().to_vec(),
-            penalty_rawtx: t.penalty_tx.serialize(),
+            penalty_rawtx: consensus::serialize(&t.penalty_tx),
         }
     }
 }

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -23,13 +23,13 @@ use bitcoin::blockdata::block::{Block, BlockHeader};
 use bitcoin::blockdata::constants::genesis_block;
 use bitcoin::blockdata::script::{Builder, Script};
 use bitcoin::blockdata::transaction::{OutPoint, Transaction, TxIn, TxOut};
+use bitcoin::consensus;
 use bitcoin::hash_types::BlockHash;
 use bitcoin::hash_types::Txid;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::Hash;
 use bitcoin::network::constants::Network;
 use bitcoin::util::hash::bitcoin_merkle_root;
-use bitcoin::util::psbt::serialize::Deserialize;
 use bitcoin::util::uint::Uint256;
 use lightning_block_sync::poll::{
     ChainPoller, Poll, Validate, ValidatedBlock, ValidatedBlockHeader,
@@ -332,7 +332,7 @@ pub(crate) fn generate_dummy_appointment(dispute_txid: Option<&Txid>) -> Extende
     };
 
     let tx_bytes = Vec::from_hex(TX_HEX).unwrap();
-    let penalty_tx = Transaction::deserialize(&tx_bytes).unwrap();
+    let penalty_tx = consensus::deserialize(&tx_bytes).unwrap();
 
     let mut raw_locator: [u8; 16] = get_random_bytes(16).try_into().unwrap();
     raw_locator.copy_from_slice(&dispute_txid[..16]);


### PR DESCRIPTION
The codebase had different ways of performing bitcoin serde:

- Using bitcoin::consensus::{encode, decode}
- Using bitcoin::util::psbt::serialize::{Deserialize, Serialize};

The former feels like a cleaner way of doing so, normalizing all the appearances.