### PR TITLE
Add rustfmt and clippy to the CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,3 +26,18 @@ jobs:
       - name: Test on Rust ${{ matrix.toolchain }}
         run: |
           cargo test --verbose --color always
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt
+      - name: Run rustfmt
+        run: |
+          cargo fmt --verbose --check -- --color always

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,10 @@ jobs:
         with:
           toolchain: stable
           profile: minimal
-          components: rustfmt
+          components: rustfmt, clippy
       - name: Run rustfmt
         run: |
           cargo fmt --verbose --check -- --color always
+      - name: Run clippy
+        run: |
+          cargo clippy --all-features --all-targets --color always -- --deny warnings

--- a/teos/src/extended_appointment.rs
+++ b/teos/src/extended_appointment.rs
@@ -11,6 +11,7 @@ use teos_common::appointment::{Appointment, Locator};
 use teos_common::UserId;
 
 /// Unique identifier used to identify appointments.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub(crate) struct UUID([u8; 20]);
 


### PR DESCRIPTION
This PR adds a new job named `lint` that runs `cargo fmt` on the project and then `cargo clippy`. This won't apply fixes, but will only report them and fail the workflow if there were any.

Further improvements:
- We can have the `build` job depending on `lint`.