### PR TITLE
Merge issue43 hotfix

### DIFF
--- a/teos/src/api/internal.rs
+++ b/teos/src/api/internal.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
 use tonic::{Code, Request, Response, Status};
-use tokio::sync::{Notify};
 use triggered::Trigger;
 
 use crate::protos as msgs;

--- a/teos/src/chain_monitor.rs
+++ b/teos/src/chain_monitor.rs
@@ -4,7 +4,7 @@
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::time;
-use tokio::sync::{Notify};
+use tokio::sync::Notify;
 use tokio::time::timeout;
 use triggered::Listener;
 
@@ -345,7 +345,7 @@ mod tests {
         // Set an async task to block on bitcoind unreachable to check that it gets notified once bitcoind comes back online
         let join_handle = tokio::spawn(async move {
             let (lock, notify) = &*bitcoind_reachable;
-            let mut reachable = *lock.lock().unwrap(); 
+            let mut reachable = *lock.lock().unwrap();
             while !reachable {
                 notify.notified().await;
                 reachable = *lock.lock().unwrap();
@@ -360,7 +360,7 @@ mod tests {
         // This would hang if the cm didn't notify their subscribers about the bitcoind status, so it serves as out assert.
         match join_handle.await {
             Ok(_) => (),
-            Err(_) => assert!(false)
+            Err(_) => assert!(false),
         };
     }
 }

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -5,7 +5,7 @@ use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use structopt::StructOpt;
-use tokio::sync::{Notify};
+use tokio::sync::Notify;
 use tokio::task;
 use tonic::transport::Server;
 

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -2,8 +2,9 @@ use simple_logger::init_with_level;
 use std::fs;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Mutex};
 use structopt::StructOpt;
+use tokio::sync::{Notify};
 use tokio::task;
 use tonic::transport::Server;
 
@@ -126,7 +127,7 @@ async fn main() {
     {
         Ok(client) => (
             Arc::new(client),
-            Arc::new((Mutex::new(true), Condvar::new())),
+            Arc::new((Mutex::new(true), Notify::new())),
         ),
         Err(e) => {
             log::error!("Failed to connect to bitcoind client: {}", e);
@@ -141,13 +142,11 @@ async fn main() {
     } else {
         ""
     };
-    let rpc = Arc::new(
-        Client::new(
-            &format!("{}{}:{}", schema, conf.btc_rpc_connect, conf.btc_rpc_port),
-            Auth::UserPass(conf.btc_rpc_user.clone(), conf.btc_rpc_password.clone()),
-        )
-        .unwrap(),
-    );
+    let rpc = Client::new(
+        &format!("{}{}:{}", schema, conf.btc_rpc_connect, conf.btc_rpc_port),
+        Auth::UserPass(conf.btc_rpc_user.clone(), conf.btc_rpc_password.clone()),
+    )
+    .unwrap();
     let mut derefed = bitcoin_cli.deref();
     // Load last known block from DB if found. Poll it from Bitcoind otherwise.
     let tip = if let Ok(block_hash) = dbm.lock().unwrap().load_last_known_block() {

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -12,7 +12,7 @@ use std::convert::TryInto;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use tokio::sync::{Notify};
+use tokio::sync::Notify;
 
 use jsonrpc_http_server::jsonrpc_core::error::ErrorCode as JsonRpcErrorCode;
 use jsonrpc_http_server::jsonrpc_core::{Error as JsonRpcError, IoHandler, Params, Value};
@@ -406,9 +406,7 @@ pub(crate) enum MockedServerQuery {
     Error(i64),
 }
 
-pub(crate) fn start_bitcoind(
-    query: MockedServerQuery,
-) -> BitcoindClient {
+pub(crate) fn start_bitcoind(query: MockedServerQuery) -> BitcoindClient {
     // Create a new bitcoind client/server
     let bitcoind_mock = match query {
         MockedServerQuery::Regular => BitcoindMock::new(MockOptions::empty()),
@@ -440,7 +438,7 @@ pub(crate) fn reset_carrier(
 pub(crate) fn create_carrier(
     query: MockedServerQuery,
     height: u32,
-    bitcoind_reachable: Arc<(Mutex<bool>, Notify)>
+    bitcoind_reachable: Arc<(Mutex<bool>, Notify)>,
 ) -> Carrier {
     let bitcoin_cli = start_bitcoind(query);
     Carrier::new(bitcoin_cli, bitcoind_reachable, height)

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -10,8 +10,9 @@
 use rand::Rng;
 use std::convert::TryInto;
 use std::ops::Deref;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Mutex};
 use std::thread;
+use tokio::sync::{Notify};
 
 use jsonrpc_http_server::jsonrpc_core::error::ErrorCode as JsonRpcErrorCode;
 use jsonrpc_http_server::jsonrpc_core::{Error as JsonRpcError, IoHandler, Params, Value};
@@ -405,15 +406,43 @@ pub(crate) enum MockedServerQuery {
     Error(i64),
 }
 
-pub(crate) fn create_carrier(query: MockedServerQuery, height: u32) -> Carrier {
+pub(crate) fn start_bitcoind(
+    query: MockedServerQuery,
+) -> BitcoindClient {
+    // Create a new bitcoind client/server
     let bitcoind_mock = match query {
         MockedServerQuery::Regular => BitcoindMock::new(MockOptions::empty()),
         MockedServerQuery::Error(x) => BitcoindMock::new(MockOptions::with_error(x)),
     };
-    let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
-    let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
+    let bitcoin_cli = BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap();
     start_server(bitcoind_mock);
+    bitcoin_cli
+}
 
+pub(crate) fn reset_carrier(
+    carrier: Arc<Carrier>,
+    query: MockedServerQuery,
+    height: u32,
+    bitcoind_reachable: bool,
+) {
+    // Create a new bitcoind client/server
+    let bitcoin_cli = start_bitcoind(query);
+
+    // Update the carrier with the new values
+    carrier.update_bitcoind_cli(bitcoin_cli);
+    carrier.update_height(height);
+    carrier.clear_receipts();
+    let (lock, _) = &*carrier.get_bitcoind_reachable();
+    let mut reachable = lock.lock().unwrap();
+    *reachable = bitcoind_reachable;
+}
+
+pub(crate) fn create_carrier(
+    query: MockedServerQuery,
+    height: u32,
+    bitcoind_reachable: Arc<(Mutex<bool>, Notify)>
+) -> Carrier {
+    let bitcoin_cli = start_bitcoind(query);
     Carrier::new(bitcoin_cli, bitcoind_reachable, height)
 }
 
@@ -423,8 +452,8 @@ pub(crate) fn create_responder(
     dbm: Arc<Mutex<DBM>>,
     server_url: &str,
 ) -> Responder {
-    let bitcoin_cli = Arc::new(BitcoindClient::new(server_url, Auth::None).unwrap());
-    let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
+    let bitcoin_cli = BitcoindClient::new(server_url, Auth::None).unwrap();
+    let bitcoind_reachable = Arc::new((Mutex::new(true), Notify::new()));
     let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, tip.deref().height);
 
     Responder::new(carrier, gatekeeper, dbm)
@@ -506,7 +535,7 @@ pub(crate) async fn create_api_with_config(api_config: ApiConfig) -> Arc<Interna
     )
     .await;
 
-    let bitcoind_reachable = Arc::new((Mutex::new(api_config.bitcoind_reachable), Condvar::new()));
+    let bitcoind_reachable = Arc::new((Mutex::new(api_config.bitcoind_reachable), Notify::new()));
     let (shutdown_trigger, _) = triggered::trigger();
     Arc::new(InternalAPI::new(
         Arc::new(watcher),


### PR DESCRIPTION
Closes #43.  `Watcher::add_appointment` spawns an `async` `tokio::task` to handle cases when `Watcher::store_triggered_appointment` runs into `bitcoind` connectivity issues.

Introducing this `async` change caused a substantial ripple effect through the code with the most notable being an update to the `Carrier` to use `tokio::sync::Notify` to listen for changes to the status of `bitcoind_reachable` (please see #43 for justification).  Other changes just further support the constraints introduced by incorporating more `async` operations.

All unit tests were updated to verify these changes and an additional test, `Watcher::test_add_appointment_bitcoind_unreachable`, was added to verify the correctness of the specific corner case presented in #43. 