### PR TITLE
Transforms the retrier into an object 

### DIFF
--- a/watchtower-plugin/src/main.rs
+++ b/watchtower-plugin/src/main.rs
@@ -22,7 +22,7 @@ use watchtower_plugin::net::http::{
     add_appointment, post_request, process_post_response, AddAppointmentError, ApiResponse,
     RequestError,
 };
-use watchtower_plugin::retrier;
+use watchtower_plugin::retrier::Retrier;
 use watchtower_plugin::wt_client::WTClient;
 use watchtower_plugin::TowerStatus;
 
@@ -427,7 +427,9 @@ async fn main() -> Result<(), Error> {
             60
         };
         tokio::spawn(async move {
-            retrier::manage_retry(rx, state_clone, max_elapsed_time, max_interval_time).await
+            Retrier::new(state_clone, max_elapsed_time, max_interval_time)
+                .manage_retry(rx)
+                .await
         });
         plugin.join().await
     } else {


### PR DESCRIPTION
Converts the retrier into an "object" and adds some minimal improvements, such as:

- minimize the amount of `lock().unwrap()`s for when accessing the `wt_client` to reduce the overhead.
- Create some tests contructors and contants to reduce the boilerplate