### PR TITLE
Adds a timeout to Python tests that may wait forever

### DIFF
--- a/watchtower-plugin/tests/pyproject.toml
+++ b/watchtower-plugin/tests/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.9"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
+pytest-timeout = "^2.1.0"
 pyln-testing = "^0.10.2"
 
 

--- a/watchtower-plugin/tests/test.py
+++ b/watchtower-plugin/tests/test.py
@@ -77,6 +77,7 @@ def test_watchtower(node_factory, bitcoind, teosd):
     assert penalty_txid in fund_txids
 
 
+@pytest.mark.timeout(60)
 def test_unreachable_watchtower(node_factory, bitcoind, teosd):
     # Set the max retry interval to 1 sec so we know how much to wait for the next retry attempt
     max_interval_time = 1


### PR DESCRIPTION
Some E2E test for the CLN plugin have conditional waits that may wait forever if the code has a bug. Set a timeout for an early fail so we don't have to waste CI time.