### PR TITLE
Add subscription_start to registration receipt

### DIFF
--- a/teos-common/proto/common/teos/v2/user.proto
+++ b/teos-common/proto/common/teos/v2/user.proto
@@ -12,8 +12,9 @@ message RegisterRequest {
   
     bytes user_id = 1;
     uint32 available_slots = 2;
-    uint32 subscription_expiry = 3;
-    string subscription_signature = 4;
+    uint32 subscription_start = 3;
+    uint32 subscription_expiry = 4;
+    string subscription_signature = 5;
   }
 
   message GetSubscriptionInfoRequest {

--- a/teos-common/src/receipts.rs
+++ b/teos-common/src/receipts.rs
@@ -6,20 +6,40 @@ use bitcoin::secp256k1::SecretKey;
 
 use crate::{cryptography, UserId};
 
-#[derive(Serialize, Debug)]
+/// Proof that a user has registered with a tower. This serves two purposes:
+///
+/// - First, the user is able to prove that the tower agreed on providing a service. If a tower refuses to accept appointments
+/// from a user (claiming the subscription has expired) but the expiry time has still not passed and the tower cannot
+/// provide the relevant appointments signed by the user, it means it is cheating.
+/// - Second, it serves as proof, alongside an appointment receipt, that an appointment was not fulfilled. A registration receipt
+/// specifies a subscription period (`subscription_start` - `subscription_expiry`) and the appointment a `start_block` so inclusion
+/// can be proved.
+///
+/// TODO: / DISCUSS: In order to minimize the amount of receipts the user has to store, the tower could batch subscription receipts
+/// as long as the user info is still known. That is, if a user has a subscription with range (S, E) and the user renews the subscription
+/// before the tower wipes their data, then the tower can create a new receipt with (S, E') for E' > E instead of a second receipt (E, E').
+// Notice this only applies as long as there is no gap between the two subscriptions.
+#[derive(Serialize, Debug, Eq, PartialEq, Clone)]
 pub struct RegistrationReceipt {
     user_id: UserId,
     available_slots: u32,
+    subscription_start: u32,
     subscription_expiry: u32,
     #[serde(skip)]
     signature: Option<String>,
 }
 
 impl RegistrationReceipt {
-    pub fn new(user_id: UserId, available_slots: u32, subscription_expiry: u32) -> Self {
+    pub fn new(
+        user_id: UserId,
+        available_slots: u32,
+        subscription_start: u32,
+        subscription_expiry: u32,
+    ) -> Self {
         RegistrationReceipt {
             user_id,
             available_slots,
+            subscription_start,
             subscription_expiry,
             signature: None,
         }
@@ -28,12 +48,14 @@ impl RegistrationReceipt {
     pub fn with_signature(
         user_id: UserId,
         available_slots: u32,
+        subscription_start: u32,
         subscription_expiry: u32,
         signature: String,
     ) -> Self {
         RegistrationReceipt {
             user_id,
             available_slots,
+            subscription_start,
             subscription_expiry,
             signature: Some(signature),
         }
@@ -45,6 +67,10 @@ impl RegistrationReceipt {
 
     pub fn available_slots(&self) -> u32 {
         self.available_slots
+    }
+
+    pub fn subscription_start(&self) -> u32 {
+        self.subscription_start
     }
 
     pub fn subscription_expiry(&self) -> u32 {
@@ -59,6 +85,7 @@ impl RegistrationReceipt {
         let mut ser = Vec::new();
         ser.extend_from_slice(&self.user_id.to_vec());
         ser.extend_from_slice(&self.available_slots.to_be_bytes());
+        ser.extend_from_slice(&self.subscription_start.to_be_bytes());
         ser.extend_from_slice(&self.subscription_expiry.to_be_bytes());
 
         ser
@@ -78,6 +105,9 @@ impl RegistrationReceipt {
     }
 }
 
+/// Proof that a certain state was backed up with the tower.
+///
+/// Appointment receipts can be used alongside a registration receipt that covers it, and on chain data (a breach not being reacted with a penalty), to prove a tower has not reacted to a channel breach.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AppointmentReceipt {
     user_signature: String,

--- a/teos-common/src/test_utils.rs
+++ b/teos-common/src/test_utils.rs
@@ -53,7 +53,26 @@ pub fn generate_random_appointment(dispute_txid: Option<&Txid>) -> Appointment {
 }
 
 pub fn get_random_registration_receipt() -> RegistrationReceipt {
-    RegistrationReceipt::new(get_random_user_id(), get_random_int(), get_random_int())
+    let (sk, _) = cryptography::get_random_keypair();
+    let start = get_random_int();
+    let mut receipt =
+        RegistrationReceipt::new(get_random_user_id(), get_random_int(), start, start + 420);
+    receipt.sign(&sk);
+
+    receipt
+}
+
+pub fn get_registration_receipt_from_previous(r: &RegistrationReceipt) -> RegistrationReceipt {
+    let (sk, _) = cryptography::get_random_keypair();
+    let mut receipt = RegistrationReceipt::new(
+        r.user_id(),
+        r.available_slots() + 1 + get_random_int::<u8>() as u32,
+        r.subscription_start(),
+        r.subscription_expiry() + 1 + get_random_int::<u8>() as u32,
+    );
+    receipt.sign(&sk);
+
+    receipt
 }
 
 pub fn get_random_appointment_receipt(tower_sk: SecretKey) -> AppointmentReceipt {

--- a/teos/src/api/internal.rs
+++ b/teos/src/api/internal.rs
@@ -77,6 +77,7 @@ impl PublicTowerServices for Arc<InternalAPI> {
             Ok(receipt) => Ok(Response::new(common_msgs::RegisterResponse {
                 user_id: req_data.user_id,
                 available_slots: receipt.available_slots(),
+                subscription_start: receipt.subscription_start(),
                 subscription_expiry: receipt.subscription_expiry(),
                 subscription_signature: receipt.signature().unwrap(),
             })),

--- a/teos/src/responder.rs
+++ b/teos/src/responder.rs
@@ -576,7 +576,8 @@ mod tests {
     use crate::test_utils::{
         create_carrier, generate_dummy_appointment_with_user, generate_uuid, get_random_breach,
         get_random_tracker, get_random_tx, store_appointment_and_fks_to_db, Blockchain,
-        MockedServerQuery, DURATION, EXPIRY_DELTA, SLOTS, START_HEIGHT,
+        MockedServerQuery, AVAILABLE_SLOTS, DURATION, EXPIRY_DELTA, SLOTS, START_HEIGHT,
+        SUBSCRIPTION_EXPIRY, SUBSCRIPTION_START,
     };
 
     use teos_common::dbm::Error as DBError;
@@ -1118,7 +1119,10 @@ mod tests {
             .dbm
             .lock()
             .unwrap()
-            .store_user(user_id, &UserInfo::new(21, 42))
+            .store_user(
+                user_id,
+                &UserInfo::new(AVAILABLE_SLOTS, SUBSCRIPTION_START, SUBSCRIPTION_EXPIRY),
+            )
             .unwrap();
 
         // Transactions are flagged to be rebroadcast when they've been in mempool for longer than CONFIRMATIONS_BEFORE_RETRY
@@ -1163,7 +1167,10 @@ mod tests {
             .dbm
             .lock()
             .unwrap()
-            .store_user(user_id, &UserInfo::new(21, 42))
+            .store_user(
+                user_id,
+                &UserInfo::new(AVAILABLE_SLOTS, SUBSCRIPTION_START, SUBSCRIPTION_EXPIRY),
+            )
             .unwrap();
 
         // Transactions are flagged to be rebroadcast when they've been in mempool for longer than CONFIRMATIONS_BEFORE_RETRY
@@ -1272,7 +1279,10 @@ mod tests {
             .dbm
             .lock()
             .unwrap()
-            .store_user(user_id, &UserInfo::new(21, 42))
+            .store_user(
+                user_id,
+                &UserInfo::new(AVAILABLE_SLOTS, SUBSCRIPTION_START, SUBSCRIPTION_EXPIRY),
+            )
             .unwrap();
 
         // Transactions are rebroadcast once they've been in mempool for CONFIRMATIONS_BEFORE_RETRY or they've been reorged out
@@ -1339,7 +1349,10 @@ mod tests {
             .dbm
             .lock()
             .unwrap()
-            .store_user(user_id, &UserInfo::new(21, 42))
+            .store_user(
+                user_id,
+                &UserInfo::new(AVAILABLE_SLOTS, SUBSCRIPTION_START, SUBSCRIPTION_EXPIRY),
+            )
             .unwrap();
 
         // Transactions are rebroadcast once they've been in mempool for CONFIRMATIONS_BEFORE_RETRY or they've been reorged out
@@ -1400,7 +1413,10 @@ mod tests {
             .dbm
             .lock()
             .unwrap()
-            .store_user(user_id, &UserInfo::new(21, 42))
+            .store_user(
+                user_id,
+                &UserInfo::new(AVAILABLE_SLOTS, SUBSCRIPTION_START, SUBSCRIPTION_EXPIRY),
+            )
             .unwrap();
 
         // Add some trackers both to memory and to the database
@@ -1454,7 +1470,10 @@ mod tests {
             .dbm
             .lock()
             .unwrap()
-            .store_user(user_id, &UserInfo::new(21, 42))
+            .store_user(
+                user_id,
+                &UserInfo::new(AVAILABLE_SLOTS, SUBSCRIPTION_START, SUBSCRIPTION_EXPIRY),
+            )
             .unwrap();
 
         // Delete trackers removes data from the trackers, tx_tracker_map maps, the database. The deletion of the later is
@@ -1504,7 +1523,14 @@ mod tests {
                 // Users will also be updated once the data is deleted.
                 // We can made up the numbers here just to check they are updated.
                 target_trackers.insert(uuid);
-                updated_users.insert(appointment.user_id, UserInfo::new(i, 42));
+                updated_users.insert(
+                    appointment.user_id,
+                    UserInfo::new(
+                        AVAILABLE_SLOTS + i,
+                        SUBSCRIPTION_START + i,
+                        SUBSCRIPTION_EXPIRY + i,
+                    ),
+                );
             }
         }
 
@@ -1826,7 +1852,10 @@ mod tests {
             .dbm
             .lock()
             .unwrap()
-            .store_user(user_id, &UserInfo::new(21, 42))
+            .store_user(
+                user_id,
+                &UserInfo::new(AVAILABLE_SLOTS, SUBSCRIPTION_START, SUBSCRIPTION_EXPIRY),
+            )
             .unwrap();
 
         let mut reorged = Vec::new();

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -52,6 +52,10 @@ pub(crate) const DURATION: u32 = 500;
 pub(crate) const EXPIRY_DELTA: u32 = 42;
 pub(crate) const START_HEIGHT: usize = 100;
 
+pub(crate) const AVAILABLE_SLOTS: u32 = 21;
+pub(crate) const SUBSCRIPTION_START: u32 = START_HEIGHT as u32;
+pub(crate) const SUBSCRIPTION_EXPIRY: u32 = SUBSCRIPTION_START + 42;
+
 #[derive(Clone, Default, Debug)]
 pub(crate) struct Blockchain {
     pub blocks: Vec<Block>,
@@ -349,8 +353,11 @@ pub(crate) fn store_appointment_and_fks_to_db(
     uuid: UUID,
     appointment: &ExtendedAppointment,
 ) {
-    dbm.store_user(appointment.user_id, &UserInfo::new(21, 42))
-        .unwrap();
+    dbm.store_user(
+        appointment.user_id,
+        &UserInfo::new(AVAILABLE_SLOTS, SUBSCRIPTION_START, SUBSCRIPTION_EXPIRY),
+    )
+    .unwrap();
     dbm.store_appointment(uuid, appointment).unwrap();
 }
 

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -892,7 +892,8 @@ mod tests {
         create_carrier, create_responder, create_watcher, generate_dummy_appointment,
         generate_dummy_appointment_with_user, generate_uuid, get_last_n_blocks, get_random_breach,
         get_random_tx, store_appointment_and_fks_to_db, BitcoindMock, Blockchain, MockOptions,
-        MockedServerQuery, DURATION, EXPIRY_DELTA, SLOTS, START_HEIGHT,
+        MockedServerQuery, AVAILABLE_SLOTS, DURATION, EXPIRY_DELTA, SLOTS, START_HEIGHT,
+        SUBSCRIPTION_EXPIRY, SUBSCRIPTION_START,
     };
     use teos_common::cryptography::{get_random_bytes, get_random_keypair};
     use teos_common::dbm::Error as DBError;
@@ -1798,7 +1799,14 @@ mod tests {
                 // Users will also be updated once the data is deleted.
                 // We can made up the numbers here just to check they are updated.
                 target_appointments.insert(uuid);
-                updated_users.insert(appointment.user_id, UserInfo::new(i, 42));
+                updated_users.insert(
+                    appointment.user_id,
+                    UserInfo::new(
+                        AVAILABLE_SLOTS + i,
+                        SUBSCRIPTION_START + i,
+                        SUBSCRIPTION_EXPIRY + i,
+                    ),
+                );
             }
         }
 

--- a/watchtower-plugin/src/dbm.rs
+++ b/watchtower-plugin/src/dbm.rs
@@ -10,7 +10,7 @@ use bitcoin::secp256k1::SecretKey;
 use teos_common::appointment::{Appointment, Locator};
 use teos_common::dbm::{DatabaseConnection, DatabaseManager, Error};
 use teos_common::receipts::{AppointmentReceipt, RegistrationReceipt};
-use teos_common::TowerId;
+use teos_common::{TowerId, UserId};
 
 use crate::{AppointmentStatus, MisbehaviorProof, TowerInfo, TowerStatus, TowerSummary};
 
@@ -18,8 +18,7 @@ const TABLES: [&str; 8] = [
     "CREATE TABLE IF NOT EXISTS towers (
     tower_id INT PRIMARY KEY,
     net_addr TEXT NOT NULL,
-    available_slots INT NOT NULL,
-    subscription_expiry INT NOT NULL
+    available_slots INT NOT NULL
 )",
     "CREATE TABLE IF NOT EXISTS appointments (
     locator INT PRIMARY KEY,
@@ -49,10 +48,12 @@ const TABLES: [&str; 8] = [
         ON DELETE CASCADE
 )",
     "CREATE TABLE IF NOT EXISTS registration_receipts (
-    tower_id INT PRIMARY KEY,
+    tower_id INT NOT NULL,
     available_slots INT NOT NULL,
+    subscription_start INT NOT NULL,
     subscription_expiry INT NOT NULL,
     signature BLOB NOT NULL,
+    PRIMARY KEY (tower_id, subscription_expiry),
     FOREIGN KEY(tower_id)
         REFERENCES towers(tower_id)
         ON DELETE CASCADE
@@ -139,24 +140,30 @@ impl DBM {
         .map_err(|_| Error::NotFound)
     }
 
-    /// Stores a tower record into the database.
+    /// Stores a tower record into the database alongside the corresponding registration receipt.
+    ///
+    /// This function MUST be guarded against inserting duplicate (tower_id, subscription_expiry) pairs.
+    /// This is currently done in WTClient::add_update_tower.
     pub fn store_tower_record(
-        &self,
+        &mut self,
         tower_id: TowerId,
         net_addr: &str,
         receipt: &RegistrationReceipt,
     ) -> Result<(), Error> {
-        let query =
-            "INSERT OR REPLACE INTO towers (tower_id, net_addr, available_slots, subscription_expiry) VALUES (?1, ?2, ?3, ?4)";
-        self.store_data(
-            query,
-            params![
-                tower_id.to_vec(),
-                net_addr,
-                receipt.available_slots(),
-                receipt.subscription_expiry()
-            ],
+        let tx = self.get_mut_connection().transaction().unwrap();
+        tx.execute(
+            "INSERT INTO towers (tower_id, net_addr, available_slots) 
+                VALUES (?1, ?2, ?3) 
+                ON CONFLICT (tower_id) DO UPDATE SET net_addr = ?2, available_slots = ?3",
+            params![tower_id.to_vec(), net_addr, receipt.available_slots()],
         )
+        .map_err(Error::Unknown)?;
+        tx.execute(
+                "INSERT INTO registration_receipts (tower_id, available_slots, subscription_start, subscription_expiry, signature) 
+                    VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![tower_id.to_vec(), receipt.available_slots(), receipt.subscription_start(), receipt.subscription_expiry(), receipt.signature()]).map_err( Error::Unknown)?;
+
+        tx.commit().map_err(Error::Unknown)
     }
 
     /// Loads a tower record from the database.
@@ -167,17 +174,23 @@ impl DBM {
     pub fn load_tower_record(&self, tower_id: TowerId) -> Result<TowerInfo, Error> {
         let mut stmt = self
         .connection
-        .prepare("SELECT net_addr, available_slots, subscription_expiry FROM towers WHERE tower_id = ?")
+        .prepare("SELECT t.net_addr, t.available_slots, r.subscription_start, r.subscription_expiry 
+                    FROM towers as t, registration_receipts as r 
+                    WHERE t.tower_id = r.tower_id AND t.tower_id = ?1 AND r.subscription_expiry = (SELECT MAX(subscription_expiry) 
+                        FROM registration_receipts 
+                        WHERE tower_id = ?1)")
         .unwrap();
 
         let mut tower = stmt
             .query_row([tower_id.to_vec()], |row| {
                 let net_addr: String = row.get(0).unwrap();
                 let available_slots: u32 = row.get(1).unwrap();
-                let subscription_expiry: u32 = row.get(2).unwrap();
+                let subscription_start: u32 = row.get(2).unwrap();
+                let subscription_expiry: u32 = row.get(3).unwrap();
                 Ok(TowerInfo::new(
                     net_addr,
                     available_slots,
+                    subscription_start,
                     subscription_expiry,
                     self.load_appointment_receipts(tower_id),
                     self.load_appointments(tower_id, AppointmentStatus::Pending),
@@ -196,10 +209,55 @@ impl DBM {
         Ok(tower)
     }
 
+    /// Loads the latest registration receipt for a given tower.
+    ///
+    /// Latests is determined by the one with the `subscription_expiry` further into the future.
+    pub fn load_registration_receipt(
+        &self,
+        tower_id: TowerId,
+        user_id: UserId,
+    ) -> Result<RegistrationReceipt, Error> {
+        let mut stmt = self
+            .connection
+            .prepare(
+                "SELECT * 
+                    FROM registration_receipts 
+                    WHERE tower_id = ?1 AND subscription_expiry = (SELECT MAX(subscription_expiry) 
+                        FROM registration_receipts 
+                        WHERE tower_id = ?1)",
+            )
+            .unwrap();
+
+        let receipt = stmt
+            .query_row([tower_id.to_vec()], |row| {
+                let slots: u32 = row.get(1).unwrap();
+                let start: u32 = row.get(2).unwrap();
+                let expiry: u32 = row.get(3).unwrap();
+                let signature: String = row.get(4).unwrap();
+
+                Ok(RegistrationReceipt::with_signature(
+                    user_id, slots, start, expiry, signature,
+                ))
+            })
+            .map_err(|_| Error::NotFound)?;
+
+        Ok(receipt)
+    }
+
     /// Loads all tower records from the database.
     pub fn load_towers(&self) -> HashMap<TowerId, TowerSummary> {
         let mut towers = HashMap::new();
-        let mut stmt = self.connection.prepare("SELECT * FROM towers").unwrap();
+        let mut stmt = self
+            .connection
+            .prepare("SELECT tw.tower_id, tw.net_addr, tw.available_slots, rr.subscription_start, rr.subscription_expiry 
+                        FROM towers AS tw 
+                        JOIN registration_receipts AS rr 
+                        JOIN (SELECT tower_id, MAX(subscription_expiry) AS max_se 
+                            FROM registration_receipts 
+                            GROUP BY tower_id) AS max_rrs ON (tw.tower_id = rr.tower_id) 
+                        AND (rr.tower_id = max_rrs.tower_id) 
+                        AND (rr.subscription_expiry = max_rrs.max_se)")
+            .unwrap();
         let mut rows = stmt.query([]).unwrap();
 
         while let Ok(Some(row)) = rows.next() {
@@ -207,12 +265,14 @@ impl DBM {
             let tower_id = TowerId::from_slice(&raw_towerid).unwrap();
             let net_addr: String = row.get(1).unwrap();
             let available_slots: u32 = row.get(2).unwrap();
-            let subscription_expiry: u32 = row.get(3).unwrap();
+            let start: u32 = row.get(3).unwrap();
+            let expiry: u32 = row.get(4).unwrap();
 
             let mut tower = TowerSummary::with_appointments(
                 net_addr,
                 available_slots,
-                subscription_expiry,
+                start,
+                expiry,
                 self.load_appointment_locators(tower_id, AppointmentStatus::Pending),
                 self.load_appointment_locators(tower_id, AppointmentStatus::Invalid),
             );
@@ -239,7 +299,8 @@ impl DBM {
     ) -> Result<(), SqliteError> {
         let tx = self.get_mut_connection().transaction().unwrap();
         tx.execute(
-            "INSERT INTO appointment_receipts (locator, tower_id, start_block, user_signature, tower_signature) VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO appointment_receipts (locator, tower_id, start_block, user_signature, tower_signature) 
+                VALUES (?1, ?2, ?3, ?4, ?5)",
             params![
                 locator.to_vec(),
                 tower_id.to_vec(),
@@ -464,7 +525,8 @@ impl DBM {
     ) -> Result<(), SqliteError> {
         let tx = self.get_mut_connection().transaction().unwrap();
         tx.execute(
-            "INSERT INTO appointment_receipts (tower_id, locator, start_block, user_signature, tower_signature) VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO appointment_receipts (tower_id, locator, start_block, user_signature, tower_signature) 
+                VALUES (?1, ?2, ?3, ?4, ?5)",
             params![
                 tower_id.to_vec(),
                 proof.locator.to_vec(),
@@ -500,11 +562,13 @@ impl DBM {
             })
             .map(|(locator, recovered_id)| {
                 let mut receipt_stmt = self
-                .connection
-                .prepare(
-                    "SELECT start_block, user_signature, tower_signature FROM appointment_receipts WHERE locator = ?1 AND tower_id = ?2",
-                )
-                .unwrap();
+                    .connection
+                    .prepare(
+                        "SELECT start_block, user_signature, tower_signature 
+                        FROM appointment_receipts 
+                        WHERE locator = ?1 AND tower_id = ?2",
+                    )
+                    .unwrap();
                 let receipt = receipt_stmt
                     .query_row([locator.to_vec(), tower_id.to_vec()], |row| {
                         let start_block = row.get::<_, u32>(0).unwrap();
@@ -518,7 +582,8 @@ impl DBM {
                     })
                     .unwrap();
                 MisbehaviorProof::new(locator, receipt, recovered_id)
-        }).map_err(|_| Error::NotFound)
+            })
+            .map_err(|_| Error::NotFound)
     }
 
     /// Checks whether a misbehaving proof exists for a given tower.
@@ -537,6 +602,7 @@ mod tests {
 
     use teos_common::test_utils::{
         generate_random_appointment, get_random_registration_receipt, get_random_user_id,
+        get_registration_receipt_from_previous,
     };
 
     impl DBM {
@@ -567,7 +633,7 @@ mod tests {
 
     #[test]
     fn test_store_load_tower_record() {
-        let dbm = DBM::in_memory().unwrap();
+        let mut dbm = DBM::in_memory().unwrap();
 
         // In order to add a tower record we need to associated registration receipt.
         let tower_id = get_random_user_id();
@@ -577,6 +643,7 @@ mod tests {
         let tower_info = TowerInfo::new(
             net_addr.into(),
             receipt.available_slots(),
+            receipt.subscription_start(),
             receipt.subscription_expiry(),
             HashMap::new(),
             Vec::new(),
@@ -587,6 +654,72 @@ mod tests {
         dbm.store_tower_record(tower_id, net_addr, &receipt)
             .unwrap();
         assert_eq!(dbm.load_tower_record(tower_id).unwrap(), tower_info);
+    }
+
+    #[test]
+    fn test_load_registration_receipt() {
+        let mut dbm = DBM::in_memory().unwrap();
+
+        // Registration receipts are stored alongside tower records when the register command is called
+        let tower_id = get_random_user_id();
+        let net_addr = "talaia.watch";
+        let receipt = get_random_registration_receipt();
+
+        // Check the receipt was stored
+        dbm.store_tower_record(tower_id, net_addr, &receipt)
+            .unwrap();
+        assert_eq!(
+            dbm.load_registration_receipt(tower_id, receipt.user_id())
+                .unwrap(),
+            receipt
+        );
+
+        // Add another receipt for the same tower with a higher expiry and check this last one is loaded
+        let middle_receipt = get_registration_receipt_from_previous(&receipt);
+        let latest_receipt = get_registration_receipt_from_previous(&middle_receipt);
+
+        dbm.store_tower_record(tower_id, net_addr, &latest_receipt)
+            .unwrap();
+        assert_eq!(
+            dbm.load_registration_receipt(tower_id, latest_receipt.user_id())
+                .unwrap(),
+            latest_receipt
+        );
+
+        // Add a final one with a lower expiry and check the last is still loaded
+        dbm.store_tower_record(tower_id, net_addr, &middle_receipt)
+            .unwrap();
+        assert_eq!(
+            dbm.load_registration_receipt(tower_id, latest_receipt.user_id())
+                .unwrap(),
+            latest_receipt
+        );
+    }
+
+    #[test]
+    fn test_load_same_registration_receipt() {
+        let mut dbm = DBM::in_memory().unwrap();
+
+        // Registration receipts are stored alongside tower records when the register command is called
+        let tower_id = get_random_user_id();
+        let net_addr = "talaia.watch";
+        let receipt = get_random_registration_receipt();
+
+        // Store it once
+        dbm.store_tower_record(tower_id, net_addr, &receipt)
+            .unwrap();
+        assert_eq!(
+            dbm.load_registration_receipt(tower_id, receipt.user_id())
+                .unwrap(),
+            receipt
+        );
+
+        // Store the same again, this should fail due to UNIQUE PK constrains.
+        // Notice store_tower_record is guarded against this by WTClient::add_update_tower though.
+        assert!(matches!(
+            dbm.store_tower_record(tower_id, net_addr, &receipt),
+            Err { .. }
+        ));
     }
 
     #[test]
@@ -603,26 +736,33 @@ mod tests {
 
     #[test]
     fn test_store_load_towers() {
-        let dbm = DBM::in_memory().unwrap();
+        let mut dbm = DBM::in_memory().unwrap();
         let mut towers = HashMap::new();
 
         // In order to add a tower record we need to associated registration receipt.
-        for _ in 0..5 {
+        for _ in 0..10 {
             let tower_id = get_random_user_id();
             let net_addr = "talaia.watch";
+            let mut receipt = get_random_registration_receipt();
+            dbm.store_tower_record(tower_id, net_addr, &receipt)
+                .unwrap();
 
-            let receipt = get_random_registration_receipt();
+            // Add not only one registration receipt to test if the tower retrieves the one with furthest expiry date.
+            for _ in 0..10 {
+                receipt = get_registration_receipt_from_previous(&receipt);
+                dbm.store_tower_record(tower_id, net_addr, &receipt)
+                    .unwrap();
+            }
+
             towers.insert(
                 tower_id,
                 TowerSummary::new(
                     net_addr.into(),
                     receipt.available_slots(),
+                    receipt.subscription_start(),
                     receipt.subscription_expiry(),
                 ),
             );
-
-            dbm.store_tower_record(tower_id, net_addr, &receipt)
-                .unwrap();
         }
 
         assert_eq!(dbm.load_towers(), towers);
@@ -647,6 +787,7 @@ mod tests {
         let mut tower_summary = TowerSummary::new(
             net_addr.into(),
             receipt.available_slots(),
+            receipt.subscription_start(),
             receipt.subscription_expiry(),
         );
         dbm.store_tower_record(tower_id, net_addr, &receipt)
@@ -694,6 +835,7 @@ mod tests {
         let tower_summary = TowerSummary::new(
             net_addr.into(),
             receipt.available_slots(),
+            receipt.subscription_start(),
             receipt.subscription_expiry(),
         );
         dbm.store_tower_record(tower_id, net_addr, &receipt)
@@ -760,6 +902,7 @@ mod tests {
         let mut tower_summary = TowerSummary::new(
             net_addr.into(),
             receipt.available_slots(),
+            receipt.subscription_start(),
             receipt.subscription_expiry(),
         )
         .with_status(TowerStatus::TemporaryUnreachable);
@@ -889,6 +1032,7 @@ mod tests {
         let mut tower_summary = TowerSummary::new(
             net_addr.into(),
             receipt.available_slots(),
+            receipt.subscription_start(),
             receipt.subscription_expiry(),
         );
         dbm.store_tower_record(tower_id, net_addr, &receipt)
@@ -951,6 +1095,7 @@ mod tests {
         let tower_summary = TowerSummary::new(
             net_addr.into(),
             receipt.available_slots(),
+            receipt.subscription_start(),
             receipt.subscription_expiry(),
         );
         dbm.store_tower_record(tower_id, net_addr, &receipt)
@@ -999,6 +1144,7 @@ mod tests {
         let tower_summary = TowerSummary::new(
             net_addr.into(),
             receipt.available_slots(),
+            receipt.subscription_start(),
             receipt.subscription_expiry(),
         );
         dbm.store_tower_record(tower_id, net_addr, &receipt)

--- a/watchtower-plugin/src/retrier.rs
+++ b/watchtower-plugin/src/retrier.rs
@@ -206,7 +206,8 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt);
+            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .unwrap();
 
         // Add appointment to pending
         let appointment = generate_random_appointment(None);
@@ -276,11 +277,11 @@ mod tests {
         let (_, tower_pk) = cryptography::get_random_keypair();
         let tower_id = TowerId(tower_pk);
         let receipt = get_random_registration_receipt();
-        wt_client.lock().unwrap().add_update_tower(
-            tower_id,
-            "http://unreachable.tower".into(),
-            &receipt,
-        );
+        wt_client
+            .lock()
+            .unwrap()
+            .add_update_tower(tower_id, "http://unreachable.tower".into(), &receipt)
+            .unwrap();
 
         // Add appointment to pending
         let appointment = generate_random_appointment(None);
@@ -344,7 +345,8 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt);
+            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .unwrap();
 
         // Add appointment to pending
         let appointment = generate_random_appointment(None);
@@ -421,7 +423,8 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt);
+            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .unwrap();
 
         // Add appointment to pending
         let appointment = generate_random_appointment(None);
@@ -486,7 +489,8 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt);
+            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .unwrap();
 
         // Add appointment to pending
         let appointment = generate_random_appointment(None);
@@ -532,7 +536,8 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt);
+            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .unwrap();
 
         // If there are no pending appointments the method will simply return
         let r = Retrier::dummy(wt_client).add_appointment(tower_id).await;
@@ -557,7 +562,8 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt);
+            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .unwrap();
 
         // Add appointment to pending
         let appointment = generate_random_appointment(None);
@@ -598,11 +604,11 @@ mod tests {
 
         // The tower we'd like to retry sending appointments to has to exist within the plugin
         let receipt = get_random_registration_receipt();
-        wt_client.lock().unwrap().add_update_tower(
-            tower_id,
-            "http://unreachable.tower".into(),
-            &receipt,
-        );
+        wt_client
+            .lock()
+            .unwrap()
+            .add_update_tower(tower_id, "http://unreachable.tower".into(), &receipt)
+            .unwrap();
 
         // Add some pending appointments and try again (with an unreachable tower).
         let appointment = generate_random_appointment(None);
@@ -631,7 +637,8 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt);
+            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .unwrap();
 
         let api_mock = server.mock(|when, then| {
             when.method(POST).path("/add_appointment");
@@ -672,7 +679,8 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt);
+            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .unwrap();
 
         let api_mock = server.mock(|when, then| {
             when.method(POST).path("/add_appointment");


### PR DESCRIPTION
Fixes #76 

## Changes:

### Common
- Updates the protos to add an additional field `RegisterRequest`. Notice this is a breaking change. Previous protos won't work with this one.

### TEOS
- Updates the gRPC server to account for the updated protos
- Updates the database. The `users` table now also stores the `subscription_start` field. This is also a breaking change.
- Adds `subscription_start` to `UserInfo` in the `Gatekeeper`
- Sets constants in tests_utils to reduce the tests boilerplate

### CLN plugin
- Updates the database. `towers` does not store the `subscription_expiry` anymore (it was being stored both there an in the `subscription_receipt`). 
    - The `subscription_start` field is added to `subscription_receipts` and the primary key updated from `tower_id` to `(tower_id, subscription_expiry)`.
    - When info regarding a tower is loaded now, it is done from both the `towers` table and the `subscription_receipts` table, picking the latest receipt for the latter.
    - Adds `load_registartion_receipt(tower_id, user_id)` that loads the latest registration receipt of a given (user_id, tower_id) pair. The latest is determined by the one with the `subscription_expiry` further into the future.
    - `store_tower_record` SQLite query has been updated from `INSERT OR REPLACE` to `UPSERT`. The rationale is that the former does delete + insert on replace, triggering the `ON DELETE` triggers for foreign keys.
- Adds `subscription_start` to both `TowerInfo` and `TowerSummary`