### PR TITLE
change `rename_all` macro value to `snake_case` for user_id

### DIFF
--- a/teos/src/cli_config.rs
+++ b/teos/src/cli_config.rs
@@ -21,7 +21,7 @@ pub enum Command {
 }
 
 #[derive(Debug, StructOpt, Clone)]
-#[structopt(rename_all = "lowercase")]
+#[structopt(rename_all = "snake_case")]
 pub struct GetUserData {
     /// The user identifier (33-byte compressed public key).
     pub user_id: String,


### PR DESCRIPTION
See https://github.com/talaia-labs/rust-teos/issues/62

cc @meryacine, let me know if I misunderstood the issue or if there are other fields I should work through in the CLI to fix as well!

```
rust-teos git:62*
λ ./target/debug/teos-cli get_user
error: The following required arguments were not provided:
    <user_id>

USAGE:
    teos-cli get_user <user_id>

For more information try --help
```