### PR TITLE
Adds some extra commands to the cln-plugin

### DIFF
--- a/watchtower-plugin/README.md
+++ b/watchtower-plugin/README.md
@@ -8,12 +8,15 @@ commitment transaction is generated. It also keeps a summary of the messages sen
 
 The plugin has the following methods:
 
-- `registertower tower_id` : registers the user id (compressed public key) with a given tower.
+- `registertower <tower_id>`: registers the user id (compressed public key) with a given tower.
+- `gettowerinfo <tower_id>`: gets all the locally stored data about a given tower.
+- `retrytower <tower_id>`: tries to send pending appointment to a (previously) unreachable tower.
+- `abandontower <tower_id>`: deletes all data associated with a given tower.
 - `listtowers`: lists all registered towers.
-- `gettowerinfo tower_id`: gets all the locally stored data about a given tower.
-- `getsubscriptioninfo tower_id`: gets the subscription information by querying the tower.
-- `retrytower tower_id`: tries to send pending appointment to a (previously) unreachable tower.
-- `getappointment tower_id locator`: queries a given tower about an appointment.
+- `getappointment <tower_id> <locator>`: queries a given tower about an appointment.
+- `getsubscriptioninfo <tower_id>`: gets the subscription information by querying the tower.
+- `getappointmentreceipt <tower_id> <locator>`: pulls a given appointment receipt from the local database.
+- `getregistrationreceipt <tower_id>`: pulls the latest registration receipt from the local database.
 
 The plugin also has an implicit method to send appointments to the registered towers for every new commitment transaction.
 

--- a/watchtower-plugin/src/retrier.rs
+++ b/watchtower-plugin/src/retrier.rs
@@ -36,10 +36,15 @@ impl Retrier {
 
         loop {
             let tower_id = unreachable_towers.recv().await.unwrap();
-            self.wt_client
-                .lock()
-                .unwrap()
-                .set_tower_status(tower_id, crate::TowerStatus::TemporaryUnreachable);
+            {
+                // Not start a retry if the tower is flagged to be abandoned
+                let mut wt_client = self.wt_client.lock().unwrap();
+                if wt_client.towers.get(&tower_id).is_none() {
+                    log::info!("Skipping retrying abandoned tower {}", tower_id);
+                    continue;
+                }
+                wt_client.set_tower_status(tower_id, crate::TowerStatus::TemporaryUnreachable);
+            }
 
             log::info!("Retrying tower {}", tower_id);
             match retry_notify(
@@ -67,15 +72,13 @@ impl Retrier {
                     // Notice we'll end up here after a permanent error. That is, either after finishing the backoff strategy
                     // unsuccessfully or by manually raising such an error (like when facing a tower misbehavior)
                     let mut wt_client = self.wt_client.lock().unwrap();
-                    if wt_client
-                        .towers
-                        .get(&tower_id)
-                        .unwrap()
-                        .status
-                        .is_unreachable()
-                    {
-                        log::warn!("Setting {} as unreachable", tower_id);
-                        wt_client.set_tower_status(tower_id, crate::TowerStatus::Unreachable);
+                    if let Some(tower) = wt_client.towers.get_mut(&tower_id) {
+                        if tower.status.is_unreachable() {
+                            log::warn!("Setting {} as unreachable", tower_id);
+                            wt_client.set_tower_status(tower_id, crate::TowerStatus::Unreachable);
+                        }
+                    } else {
+                        log::info!("Skipping retrying abandoned tower {}", tower_id);
                     }
                 }
             }
@@ -86,6 +89,10 @@ impl Retrier {
         // Create a new scope so we can get all the data only locking the WTClient once.
         let (appointments, net_addr, user_sk) = {
             let wt_client = self.wt_client.lock().unwrap();
+            if wt_client.towers.get(&tower_id).is_none() {
+                return Err(Error::permanent("Tower was abandoned. Skipping retry"));
+            }
+
             let appointments = wt_client
                 .dbm
                 .lock()
@@ -410,7 +417,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_retry_misbehaving() {
+    async fn test_manage_retry_misbehaving() {
         let tmp_path = &format!(".watchtower_{}/", get_random_user_id());
         let (tx, rx) = unbounded_channel();
         let wt_client = Arc::new(Mutex::new(WTClient::new(tmp_path.into(), tx.clone()).await));
@@ -469,6 +476,43 @@ mod tests {
             .status
             .is_misbehaving());
         api_mock.assert();
+
+        task.abort();
+        fs::remove_dir_all(tmp_path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_manage_retry_abandoned() {
+        let tmp_path = &format!(".watchtower_{}/", get_random_user_id());
+        let (tx, rx) = unbounded_channel();
+        let wt_client = Arc::new(Mutex::new(WTClient::new(tmp_path.into(), tx.clone()).await));
+        let server = MockServer::start();
+
+        // Add a tower with pending appointments
+        let (_, tower_pk) = cryptography::get_random_keypair();
+        let tower_id = TowerId(tower_pk);
+        let receipt = get_random_registration_receipt();
+        wt_client
+            .lock()
+            .unwrap()
+            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .unwrap();
+
+        // Remove the tower (to simulate it has been abandoned)
+        wt_client.lock().unwrap().remove_tower(tower_id).unwrap();
+
+        // Start the task and send the tower to the channel for retry
+        let wt_client_clone = wt_client.clone();
+        let task = tokio::spawn(async move {
+            Retrier::new(wt_client_clone, MAX_ELAPSED_TIME, MAX_INTERVAL_TIME)
+                .manage_retry(rx)
+                .await
+        });
+
+        // Send the id and check how it gets removed
+        tx.send(tower_id).unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(!wt_client.lock().unwrap().towers.contains_key(&tower_id));
 
         task.abort();
         fs::remove_dir_all(tmp_path).await.unwrap();
@@ -712,6 +756,38 @@ mod tests {
             .unwrap()
             .invalid_appointments
             .contains(&appointment.locator));
+
+        fs::remove_dir_all(tmp_path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_add_appointment_abandoned() {
+        let (_, tower_pk) = cryptography::get_random_keypair();
+        let tower_id = TowerId(tower_pk);
+        let tmp_path = &format!(".watchtower_{}/", get_random_user_id());
+        let wt_client = Arc::new(Mutex::new(
+            WTClient::new(tmp_path.into(), unbounded_channel().0).await,
+        ));
+        let server = MockServer::start();
+
+        // The tower we'd like to retry sending appointments to has to exist within the plugin
+        let receipt = get_random_registration_receipt();
+        wt_client
+            .lock()
+            .unwrap()
+            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .unwrap();
+
+        // Remove the tower (to simulate it has been abandoned)
+        wt_client.lock().unwrap().remove_tower(tower_id).unwrap();
+
+        // If there are no pending appointments the method will simply return
+        let r = Retrier::dummy(wt_client).add_appointment(tower_id).await;
+
+        assert_eq!(
+            r,
+            Err(Error::permanent("Tower was abandoned. Skipping retry"))
+        );
 
         fs::remove_dir_all(tmp_path).await.unwrap();
     }

--- a/watchtower-plugin/src/wt_client.rs
+++ b/watchtower-plugin/src/wt_client.rs
@@ -116,6 +116,17 @@ impl WTClient {
         Ok(())
     }
 
+    /// Gets the latest registration receipt of a given tower.
+    pub fn get_registration_receipt(
+        &self,
+        tower_id: TowerId,
+    ) -> Result<RegistrationReceipt, DBError> {
+        self.dbm
+            .lock()
+            .unwrap()
+            .load_registration_receipt(tower_id, self.user_id)
+    }
+
     /// Loads a tower record from the database.
     pub fn load_tower_info(&self, tower_id: TowerId) -> Result<TowerInfo, DBError> {
         self.dbm.lock().unwrap().load_tower_record(tower_id)
@@ -157,6 +168,18 @@ impl WTClient {
                 tower_id
             );
         }
+    }
+
+    /// Gets an appointment receipt from the database (if found).
+    pub fn get_appointment_receipt(
+        &self,
+        tower_id: TowerId,
+        locator: Locator,
+    ) -> Result<AppointmentReceipt, DBError> {
+        self.dbm
+            .lock()
+            .unwrap()
+            .load_appointment_receipt(tower_id, locator)
     }
 
     /// Adds a pending appointment to the tower record.
@@ -224,6 +247,18 @@ impl WTClient {
             tower.status = TowerStatus::Misbehaving;
         } else {
             log::error!("Cannot flag tower. Unknown tower_id: {}", tower_id);
+        }
+    }
+
+    /// Removes a tower from the client (both memory and database).
+    ///
+    /// Any data associated to the tower will be deleted (i.e. links to appointments)
+    pub fn remove_tower(&mut self, tower_id: TowerId) -> Result<(), DBError> {
+        if self.towers.contains_key(&tower_id) {
+            self.towers.remove(&tower_id);
+            self.dbm.lock().unwrap().remove_tower_record(tower_id)
+        } else {
+            Err(DBError::NotFound)
         }
     }
 }
@@ -704,5 +739,167 @@ mod tests {
         assert_eq!(loaded_info.status, TowerStatus::Misbehaving);
         assert_eq!(loaded_info.misbehaving_proof, Some(proof));
         assert!(loaded_info.appointments.contains_key(&appointment.locator));
+    }
+
+    #[tokio::test]
+    async fn test_remove_tower() {
+        let tmp_path = &format!(".watchtower_{}/", get_random_user_id());
+        let mut wt_client = WTClient::new(tmp_path.into(), unbounded_channel().0).await;
+
+        let receipt = get_random_registration_receipt();
+        let (tower_sk, tower_pk) = cryptography::get_random_keypair();
+        let tower_id = TowerId(tower_pk);
+        let tower_info = TowerInfo::empty(
+            "talaia.watch".into(),
+            receipt.available_slots(),
+            receipt.subscription_start(),
+            receipt.subscription_expiry(),
+        );
+
+        // Add the tower and check it is there
+        wt_client
+            .add_update_tower(tower_id, tower_info.net_addr.clone(), &receipt)
+            .unwrap();
+        assert_eq!(
+            wt_client.towers.get(&tower_id),
+            Some(&TowerSummary::from(tower_info.clone()))
+        );
+        assert_eq!(wt_client.load_tower_info(tower_id).unwrap(), tower_info);
+
+        // Remove the tower and check it is not there anymore
+        wt_client.remove_tower(tower_id).unwrap();
+        assert!(matches!(
+            wt_client.load_tower_info(tower_id),
+            Err(DBError::NotFound)
+        ));
+        assert!(!wt_client.towers.contains_key(&tower_id));
+
+        // Try again but this time with an associated appointment to check that it also gets removed
+        wt_client
+            .add_update_tower(tower_id, tower_info.net_addr, &receipt)
+            .unwrap();
+
+        let locator = generate_random_appointment(None).locator;
+        let registration_receipt = get_random_registration_receipt();
+        let appointment_receipt = get_random_appointment_receipt(tower_sk);
+
+        // If we call this on an unknown tower it will simply do nothing
+        wt_client.add_appointment_receipt(
+            tower_id,
+            locator,
+            registration_receipt.available_slots(),
+            &appointment_receipt,
+        );
+        assert!(wt_client
+            .dbm
+            .lock()
+            .unwrap()
+            .appointment_receipt_exists(locator, tower_id));
+
+        // Remove and check both the tower and the appointment
+        wt_client.remove_tower(tower_id).unwrap();
+        assert!(matches!(
+            wt_client.load_tower_info(tower_id),
+            Err(DBError::NotFound)
+        ));
+        assert!(!wt_client.towers.contains_key(&tower_id));
+        assert!(!wt_client
+            .dbm
+            .lock()
+            .unwrap()
+            .appointment_receipt_exists(locator, tower_id));
+
+        fs::remove_dir_all(tmp_path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_remove_tower_shared_appointment() {
+        // Lets test removing a tower that has associated data shared with another tower.
+        // For instance, having an appointment that was sent to two towers, and then deleting one of them
+        // should only remove the link between the tower and the appointment, but not delete the data.
+        let tmp_path = &format!(".watchtower_{}/", get_random_user_id());
+        let mut wt_client = WTClient::new(tmp_path.into(), unbounded_channel().0).await;
+
+        let receipt = get_random_registration_receipt();
+        let (tower1_sk, tower1_pk) = cryptography::get_random_keypair();
+        let tower1_id = TowerId(tower1_pk);
+        let (tower2_sk, tower2_pk) = cryptography::get_random_keypair();
+        let tower2_id = TowerId(tower2_pk);
+
+        let tower_info = TowerInfo::empty(
+            "talaia.watch".into(),
+            receipt.available_slots(),
+            receipt.subscription_start(),
+            receipt.subscription_expiry(),
+        );
+        wt_client
+            .add_update_tower(tower1_id, tower_info.net_addr.clone(), &receipt)
+            .unwrap();
+        wt_client
+            .add_update_tower(tower2_id, tower_info.net_addr, &receipt)
+            .unwrap();
+
+        let locator = generate_random_appointment(None).locator;
+        let registration_receipt = get_random_registration_receipt();
+        let appointment_receipt_1 = get_random_appointment_receipt(tower1_sk);
+        let appointment_receipt_2 = get_random_appointment_receipt(tower2_sk);
+
+        wt_client.add_appointment_receipt(
+            tower1_id,
+            locator,
+            registration_receipt.available_slots(),
+            &appointment_receipt_1,
+        );
+        wt_client.add_appointment_receipt(
+            tower2_id,
+            locator,
+            registration_receipt.available_slots(),
+            &appointment_receipt_2,
+        );
+
+        // Check that the data exists in both towers
+        assert!(wt_client
+            .dbm
+            .lock()
+            .unwrap()
+            .appointment_receipt_exists(locator, tower1_id));
+        assert!(wt_client
+            .dbm
+            .lock()
+            .unwrap()
+            .appointment_receipt_exists(locator, tower2_id));
+
+        // Remove tower1 and check that the appointment receipt can still be found for tower2
+        wt_client.remove_tower(tower1_id).unwrap();
+        assert!(matches!(
+            wt_client.load_tower_info(tower1_id),
+            Err(DBError::NotFound)
+        ));
+
+        assert!(!wt_client
+            .dbm
+            .lock()
+            .unwrap()
+            .appointment_receipt_exists(locator, tower1_id));
+        assert!(wt_client
+            .dbm
+            .lock()
+            .unwrap()
+            .appointment_receipt_exists(locator, tower2_id));
+
+        fs::remove_dir_all(tmp_path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_remove_inexistent_tower() {
+        let tmp_path = &format!(".watchtower_{}/", get_random_user_id());
+        let mut wt_client = WTClient::new(tmp_path.into(), unbounded_channel().0).await;
+
+        assert!(matches!(
+            wt_client.remove_tower(get_random_user_id()),
+            Err(DBError::NotFound)
+        ));
+
+        fs::remove_dir_all(tmp_path).await.unwrap();
     }
 }

--- a/watchtower-plugin/src/wt_client.rs
+++ b/watchtower-plugin/src/wt_client.rs
@@ -514,8 +514,6 @@ mod tests {
             .lock()
             .unwrap()
             .appointment_exists(appointment.locator));
-
-        fs::remove_dir_all(tmp_path).await.unwrap();
     }
 
     #[tokio::test]
@@ -608,8 +606,6 @@ mod tests {
             .lock()
             .unwrap()
             .appointment_exists(appointment.locator));
-
-        fs::remove_dir_all(tmp_path).await.unwrap();
     }
 
     #[tokio::test]
@@ -701,8 +697,6 @@ mod tests {
             .lock()
             .unwrap()
             .appointment_exists(appointment.locator));
-
-        fs::remove_dir_all(tmp_path).await.unwrap();
     }
 
     #[tokio::test]
@@ -743,8 +737,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_tower() {
-        let tmp_path = &format!(".watchtower_{}/", get_random_user_id());
-        let mut wt_client = WTClient::new(tmp_path.into(), unbounded_channel().0).await;
+        let tmp_path = TempDir::new(&format!("watchtower_{}", get_random_user_id())).unwrap();
+        let mut wt_client =
+            WTClient::new(tmp_path.path().to_path_buf(), unbounded_channel().0).await;
 
         let receipt = get_random_registration_receipt();
         let (tower_sk, tower_pk) = cryptography::get_random_keypair();
@@ -808,8 +803,6 @@ mod tests {
             .lock()
             .unwrap()
             .appointment_receipt_exists(locator, tower_id));
-
-        fs::remove_dir_all(tmp_path).await.unwrap();
     }
 
     #[tokio::test]
@@ -817,8 +810,9 @@ mod tests {
         // Lets test removing a tower that has associated data shared with another tower.
         // For instance, having an appointment that was sent to two towers, and then deleting one of them
         // should only remove the link between the tower and the appointment, but not delete the data.
-        let tmp_path = &format!(".watchtower_{}/", get_random_user_id());
-        let mut wt_client = WTClient::new(tmp_path.into(), unbounded_channel().0).await;
+        let tmp_path = TempDir::new(&format!("watchtower_{}", get_random_user_id())).unwrap();
+        let mut wt_client =
+            WTClient::new(tmp_path.path().to_path_buf(), unbounded_channel().0).await;
 
         let receipt = get_random_registration_receipt();
         let (tower1_sk, tower1_pk) = cryptography::get_random_keypair();
@@ -886,20 +880,17 @@ mod tests {
             .lock()
             .unwrap()
             .appointment_receipt_exists(locator, tower2_id));
-
-        fs::remove_dir_all(tmp_path).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_remove_inexistent_tower() {
-        let tmp_path = &format!(".watchtower_{}/", get_random_user_id());
-        let mut wt_client = WTClient::new(tmp_path.into(), unbounded_channel().0).await;
+        let tmp_path = TempDir::new(&format!("watchtower_{}", get_random_user_id())).unwrap();
+        let mut wt_client =
+            WTClient::new(tmp_path.path().to_path_buf(), unbounded_channel().0).await;
 
         assert!(matches!(
             wt_client.remove_tower(get_random_user_id()),
             Err(DBError::NotFound)
         ));
-
-        fs::remove_dir_all(tmp_path).await.unwrap();
     }
 }


### PR DESCRIPTION
### Changes:

- `abandontower <tower_id>` will remove all data associated with a given tower. If the tower is being retried, the retry strategy will be aborted on the next iteration.
- `getappointmentreceipt <tower_id> <locator>` will pull a given appointment receipt from the local database.
- `getregistrationreceipt <tower_id>` will pull the latest registration receipt from the local database.

### Followups:

- Add some optional parameters to `getregistrationreceipt` so a period can be specified. If present, the receipt matching that period will be pulled (if any).