### PR TITLE
feat(lightning): Add Lightning as transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "base64-compat",
  "bech32",
  "bitcoin_hashes",
+ "bitcoinconsensus",
  "secp256k1",
  "serde",
 ]
@@ -335,6 +336,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitcoinconsensus"
+version = "0.19.0-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8aa43b5cd02f856cb126a9af819e77b8910fdd74dd1407be649f2f5fe3a1b5"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1713,6 +1724,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d885bf509066af86ae85354c8959028ad6192c22a2657ef8271e94029d30f9d0"
 dependencies = [
  "bitcoin",
+ "hex",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,7 @@ version = "0.2.0"
 dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
+ "futures",
  "hex",
  "home",
  "jsonrpc-http-server",

--- a/teos-common/Cargo.toml
+++ b/teos-common/Cargo.toml
@@ -25,3 +25,6 @@ lightning = "0.0.108"
 
 [build-dependencies]
 tonic-build = "0.6"
+
+[dev-dependencies]
+lightning = { version = "0.0.108", features = ["_test_utils"] }

--- a/teos-common/src/lib.rs
+++ b/teos-common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod constants;
 pub mod cryptography;
 pub mod dbm;
 pub mod errors;
+pub mod lightning;
 pub mod net;
 pub mod receipts;
 pub mod ser;

--- a/teos-common/src/lightning/convert.rs
+++ b/teos-common/src/lightning/convert.rs
@@ -1,0 +1,145 @@
+//! A module that implements useful gRPC messages to lightning message conversions.
+
+use super::messages::*;
+use crate::appointment::Locator;
+use crate::constants::ENCRYPTED_BLOB_MAX_SIZE;
+use crate::protos as msgs;
+
+use bitcoin::hashes::Hash;
+use bitcoin::Txid;
+
+/// Conversions from individual messages to tower messages.
+mod msg_to_tower_msg {
+    use super::*;
+    macro_rules! impl_from_msg {
+        ($msg: ident) => {
+            impl From<$msg> for TowerMessage {
+                fn from(m: $msg) -> TowerMessage {
+                    TowerMessage::$msg(m)
+                }
+            }
+        };
+    }
+
+    impl_from_msg!(Register);
+    impl_from_msg!(SubscriptionDetails);
+    impl_from_msg!(AddUpdateAppointment);
+    impl_from_msg!(AppointmentAccepted);
+    impl_from_msg!(AppointmentRejected);
+    impl_from_msg!(GetAppointment);
+    impl_from_msg!(AppointmentData);
+    impl_from_msg!(TrackerData);
+    impl_from_msg!(AppointmentNotFound);
+    impl_from_msg!(GetSubscriptionInfo);
+    impl_from_msg!(SubscriptionInfo);
+}
+
+// FIXME: There are a lot of `unwrap()`s in these conversions. We assume that the gRPC interface won't send invalid data.
+// If the conversion panics this would crash the lightning server.
+
+/// Conversion from user requests to gRPC requests.
+/// These are used by the tower when routing lightning requests to its internal gRPC server.
+mod msg_to_grpc {
+    use super::*;
+    impl From<Register> for msgs::RegisterRequest {
+        fn from(r: Register) -> Self {
+            msgs::RegisterRequest {
+                user_id: r.pubkey.to_vec(),
+            }
+        }
+    }
+
+    impl From<AddUpdateAppointment> for msgs::AddAppointmentRequest {
+        fn from(r: AddUpdateAppointment) -> Self {
+            let appointment = msgs::Appointment {
+                locator: r.locator.to_vec(),
+                encrypted_blob: r.encrypted_blob,
+                to_self_delay: r.to_self_delay.unwrap_or(42),
+            };
+
+            msgs::AddAppointmentRequest {
+                appointment: Some(appointment),
+                signature: r.signature,
+            }
+        }
+    }
+
+    impl From<GetAppointment> for msgs::GetAppointmentRequest {
+        fn from(r: GetAppointment) -> Self {
+            msgs::GetAppointmentRequest {
+                locator: r.locator.to_vec(),
+                signature: r.signature,
+            }
+        }
+    }
+
+    impl From<GetSubscriptionInfo> for msgs::GetSubscriptionInfoRequest {
+        fn from(r: GetSubscriptionInfo) -> Self {
+            msgs::GetSubscriptionInfoRequest {
+                signature: r.signature,
+            }
+        }
+    }
+}
+
+/// Conversion from gRPC responses to tower responses.
+/// These are used by the tower when parsing internal gRPC server's responses.
+mod grpc_to_tower_msg {
+    use super::*;
+    impl From<msgs::RegisterResponse> for TowerMessage {
+        fn from(r: msgs::RegisterResponse) -> Self {
+            SubscriptionDetails {
+                appointment_max_size: ENCRYPTED_BLOB_MAX_SIZE as u16,
+                start_block: r.subscription_start,
+                amount_msat: None,
+                invoice: None,
+                signature: Some(r.subscription_signature),
+            }
+            .into()
+        }
+    }
+
+    impl From<msgs::AddAppointmentResponse> for TowerMessage {
+        fn from(r: msgs::AddAppointmentResponse) -> Self {
+            AppointmentAccepted {
+                locator: Locator::from_slice(&r.locator).unwrap(),
+                start_block: r.start_block,
+                receipt_signature: Some(r.signature),
+            }
+            .into()
+        }
+    }
+
+    impl From<msgs::GetAppointmentResponse> for TowerMessage {
+        fn from(r: msgs::GetAppointmentResponse) -> Self {
+            match r.appointment_data.unwrap().appointment_data.unwrap() {
+                msgs::appointment_data::AppointmentData::Appointment(a) => AppointmentData {
+                    locator: Locator::from_slice(&a.locator).unwrap(),
+                    encrypted_blob: a.encrypted_blob,
+                }
+                .into(),
+                msgs::appointment_data::AppointmentData::Tracker(t) => TrackerData {
+                    dispute_txid: Txid::from_slice(&t.dispute_txid).unwrap(),
+                    penalty_txid: Txid::from_slice(&t.penalty_txid).unwrap(),
+                    penalty_rawtx: t.penalty_rawtx,
+                }
+                .into(),
+            }
+        }
+    }
+
+    impl From<msgs::GetSubscriptionInfoResponse> for TowerMessage {
+        fn from(r: msgs::GetSubscriptionInfoResponse) -> Self {
+            SubscriptionInfo {
+                available_slots: r.available_slots,
+                subscription_expiry: r.subscription_expiry,
+                locators: r
+                    .locators
+                    .into_iter()
+                    .map(|l| Locator::from_slice(&l).unwrap())
+                    .collect(),
+            }
+            .into()
+        }
+    }
+}

--- a/teos-common/src/lightning/messages.rs
+++ b/teos-common/src/lightning/messages.rs
@@ -26,6 +26,7 @@ pub struct Register {
 #[derive(Debug)]
 pub struct SubscriptionDetails {
     pub appointment_max_size: u16,
+    pub start_block: u32,
     pub amount_msat: u32,
     // Optional TLV.
     pub invoice: Option<String>,
@@ -112,6 +113,7 @@ impl_writeable_msg!(Register, {
 
 impl_writeable_msg!(SubscriptionDetails, {
     appointment_max_size,
+    start_block,
     amount_msat,
 }, {
     // Use `opt_str` and not `opt` to avoid writing a length prefix for strings
@@ -273,6 +275,7 @@ mod tests {
         });
         test_msg(SubscriptionDetails {
             appointment_max_size: 3032,
+            start_block: 358943,
             amount_msat: 41893,
             invoice: None,
             signature: None,
@@ -323,12 +326,13 @@ mod tests {
     fn test_tower_message_with_tlvs() {
         test_msg(SubscriptionDetails {
             appointment_max_size: 4498,
+            start_block: 4934503,
             amount_msat: 891431,
             invoice: Some(String::from(
                 "lnbc100p1psj9jhxdqud3jxktt5w46x7unfv9kz6mn0v3jsnp4q0d3p2sfluzdx45...",
             )),
             signature: Some(String::from(
-                "sign: user_pubkey || appointment_max_size || amount_msat || invoice_id?",
+                "sign: user_pubkey || appointment_max_size || start_block || amount_msat || invoice_id?",
             )),
         });
         test_msg(AddUpdateAppointment {

--- a/teos-common/src/lightning/messages.rs
+++ b/teos-common/src/lightning/messages.rs
@@ -1,0 +1,243 @@
+//! Watchtower custom lightning messages that implement LDK's [`Readable`] & [`Writeable`] traits.
+//!
+//! [`Readable`]: lightning::util::ser::Readable
+
+use crate::appointment::Locator;
+use crate::lightning::ser_macros::{impl_writeable_msg, set_msg_type};
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::Txid;
+use lightning::io::Error;
+use lightning::ln::wire;
+use lightning::util::ser::{Writeable, Writer};
+
+// Re-exporting this for other crates to use.
+pub use crate::lightning::ser_utils::Type;
+
+/// The register message sent by the user to subscribe for the watching service.
+#[derive(Debug)]
+pub struct Register {
+    pub pubkey: PublicKey,
+    pub appointment_slots: u32,
+    pub subscription_period: u32,
+}
+
+/// The subscription details message that is sent to the user after registering or toping up.
+/// This message is the response to the register message.
+#[derive(Debug)]
+pub struct SubscriptionDetails {
+    pub appointment_max_size: u16,
+    pub amount_msat: u32,
+    // Optional TLV.
+    pub invoice: Option<String>,
+    pub signature: Option<String>,
+}
+
+/// The add/update appointment message sent by the user.
+#[derive(Debug)]
+pub struct AddUpdateAppointment {
+    pub locator: Locator,
+    // NOTE: LDK will prefix varying size fields (e.g. vectors and strings) with their length.
+    pub encrypted_blob: Vec<u8>,
+    pub signature: String,
+    // Optional TLV.
+    pub to_self_delay: Option<u64>,
+}
+
+/// The appointment accepted message that is sent after an accepted add/update appointment message.
+#[derive(Debug)]
+pub struct AppointmentAccepted {
+    pub locator: Locator,
+    pub start_block: u32,
+    // Optional TLV.
+    pub receipt_signature: Option<String>,
+}
+
+/// The appointment rejected message that is sent if an add/update appointment message was rejected.
+#[derive(Debug)]
+pub struct AppointmentRejected {
+    pub locator: Locator,
+    pub rcode: u16,
+    pub reason: String,
+}
+
+/// The get appointment message sent by the user to retrieve a previously sent appointment from the tower.
+#[derive(Debug)]
+pub struct GetAppointment {
+    pub locator: Locator,
+    pub signature: String,
+}
+
+/// The appointment data message sent by the tower after a get appointment message.
+#[derive(Debug)]
+pub struct AppointmentData {
+    pub locator: Locator,
+    pub encrypted_blob: Vec<u8>,
+}
+
+/// The tracker data message sent by the tower when the requested appointment has been acted upon.
+#[derive(Debug)]
+pub struct TrackerData {
+    pub dispute_txid: Txid,
+    pub penalty_txid: Txid,
+    pub penalty_rawtx: Vec<u8>,
+}
+
+/// The appointment not found message sent by the tower in response to a get appointment message
+/// whose locator didn't match any known appointment.
+#[derive(Debug)]
+pub struct AppointmentNotFound {
+    pub locator: Locator,
+}
+
+/// The get subscription info message (a TEOS custom message, not a bolt13 one).
+#[derive(Debug)]
+pub struct GetSubscriptionInfo {
+    pub signature: String,
+}
+
+/// The subscription info message sent by the tower in response to get subscription info message.
+#[derive(Debug)]
+pub struct SubscriptionInfo {
+    pub available_slots: u32,
+    pub subscription_expiry: u32,
+    // Sent as a TLV. Defaults to an empty vector.
+    pub locators: Vec<Locator>,
+}
+
+impl_writeable_msg!(Register, {
+    pubkey,
+    appointment_slots,
+    subscription_period
+}, {});
+
+impl_writeable_msg!(SubscriptionDetails, {
+    appointment_max_size,
+    amount_msat,
+}, {
+    // Use `opt_str` and not `opt` to avoid writing a length prefix for strings
+    // since it's already written in the length part of the TLV.
+    (1, invoice, opt_str),
+    (3, signature, opt_str),
+});
+
+impl_writeable_msg!(AddUpdateAppointment, {
+    locator,
+    encrypted_blob,
+    signature,
+}, {
+    (1, to_self_delay, opt),
+});
+
+impl_writeable_msg!(AppointmentAccepted, {
+    locator,
+    start_block,
+}, {
+    // Use `opt_str` and not `opt` to avoid writing a length prefix for strings
+    // since it's already written in the length part of the TLV.
+    (1, receipt_signature, opt_str),
+});
+
+impl_writeable_msg!(AppointmentRejected, {
+    locator,
+    rcode,
+    reason,
+}, {});
+
+impl_writeable_msg!(GetAppointment, {
+    locator,
+    signature,
+}, {});
+
+impl_writeable_msg!(AppointmentData, {
+    locator,
+    encrypted_blob,
+}, {});
+
+impl_writeable_msg!(TrackerData, {
+    dispute_txid,
+    penalty_txid,
+    penalty_rawtx,
+}, {});
+
+impl_writeable_msg!(AppointmentNotFound, {
+    locator,
+}, {});
+
+impl_writeable_msg!(GetSubscriptionInfo, {
+    signature,
+}, {});
+
+impl_writeable_msg!(SubscriptionInfo, {
+    available_slots,
+    subscription_expiry,
+}, {
+    (1, locators, vec)
+});
+
+set_msg_type!(Register, 48848);
+set_msg_type!(SubscriptionDetails, 48850);
+set_msg_type!(AddUpdateAppointment, 48852);
+set_msg_type!(AppointmentAccepted, 48854);
+set_msg_type!(AppointmentRejected, 48856);
+set_msg_type!(GetAppointment, 48858);
+set_msg_type!(AppointmentData, 48860);
+set_msg_type!(TrackerData, 48862);
+set_msg_type!(AppointmentNotFound, 48864);
+// Let these messages get odd types since they are auxiliary messages.
+set_msg_type!(GetSubscriptionInfo, 48865);
+set_msg_type!(SubscriptionInfo, 48867);
+
+#[derive(Debug)]
+pub enum TowerMessage {
+    // Register messages
+    Register(Register),
+    SubscriptionDetails(SubscriptionDetails),
+    // Appointment submission messages
+    AddUpdateAppointment(AddUpdateAppointment),
+    AppointmentAccepted(AppointmentAccepted),
+    AppointmentRejected(AppointmentRejected),
+    // Appointment fetching messages
+    GetAppointment(GetAppointment),
+    AppointmentData(AppointmentData),
+    TrackerData(TrackerData),
+    AppointmentNotFound(AppointmentNotFound),
+    // User subscription messages
+    GetSubscriptionInfo(GetSubscriptionInfo),
+    SubscriptionInfo(SubscriptionInfo),
+}
+
+impl wire::Type for TowerMessage {
+    fn type_id(&self) -> u16 {
+        match self {
+            TowerMessage::Register(..) => Register::TYPE,
+            TowerMessage::SubscriptionDetails(..) => SubscriptionDetails::TYPE,
+            TowerMessage::AddUpdateAppointment(..) => AddUpdateAppointment::TYPE,
+            TowerMessage::AppointmentAccepted(..) => AppointmentAccepted::TYPE,
+            TowerMessage::AppointmentRejected(..) => AppointmentRejected::TYPE,
+            TowerMessage::GetAppointment(..) => GetAppointment::TYPE,
+            TowerMessage::AppointmentData(..) => AppointmentData::TYPE,
+            TowerMessage::TrackerData(..) => TrackerData::TYPE,
+            TowerMessage::AppointmentNotFound(..) => AppointmentNotFound::TYPE,
+            TowerMessage::GetSubscriptionInfo(..) => GetSubscriptionInfo::TYPE,
+            TowerMessage::SubscriptionInfo(..) => SubscriptionInfo::TYPE,
+        }
+    }
+}
+
+impl Writeable for TowerMessage {
+    fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+        match self {
+            TowerMessage::Register(msg) => msg.write(writer),
+            TowerMessage::SubscriptionDetails(msg) => msg.write(writer),
+            TowerMessage::AddUpdateAppointment(msg) => msg.write(writer),
+            TowerMessage::AppointmentAccepted(msg) => msg.write(writer),
+            TowerMessage::AppointmentRejected(msg) => msg.write(writer),
+            TowerMessage::GetAppointment(msg) => msg.write(writer),
+            TowerMessage::AppointmentData(msg) => msg.write(writer),
+            TowerMessage::TrackerData(msg) => msg.write(writer),
+            TowerMessage::AppointmentNotFound(msg) => msg.write(writer),
+            TowerMessage::GetSubscriptionInfo(msg) => msg.write(writer),
+            TowerMessage::SubscriptionInfo(msg) => msg.write(writer),
+        }
+    }
+}

--- a/teos-common/src/lightning/messages.rs
+++ b/teos-common/src/lightning/messages.rs
@@ -15,7 +15,7 @@ use lightning::util::ser::{Writeable, Writer};
 pub use crate::lightning::ser_utils::Type;
 
 /// The register message sent by the user to subscribe for the watching service.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Register {
     pub pubkey: UserId,
     pub appointment_slots: u32,
@@ -24,7 +24,7 @@ pub struct Register {
 
 /// The subscription details message that is sent to the user after registering or toping up.
 /// This message is the response to the register message.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SubscriptionDetails {
     pub appointment_max_size: u16,
     pub start_block: u32,
@@ -35,17 +35,18 @@ pub struct SubscriptionDetails {
 }
 
 /// The add/update appointment message sent by the user.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AddUpdateAppointment {
     pub locator: Locator,
     pub encrypted_blob: Vec<u8>,
     pub signature: String,
     // Optional TLV.
-    pub to_self_delay: Option<u64>,
+    // FIXME: BOLT13 uses u64.
+    pub to_self_delay: Option<u32>,
 }
 
 /// The appointment accepted message that is sent after an accepted add/update appointment message.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AppointmentAccepted {
     pub locator: Locator,
     pub start_block: u32,
@@ -54,7 +55,7 @@ pub struct AppointmentAccepted {
 }
 
 /// The appointment rejected message that is sent if an add/update appointment message was rejected.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AppointmentRejected {
     pub locator: Locator,
     pub rcode: u16,
@@ -62,21 +63,21 @@ pub struct AppointmentRejected {
 }
 
 /// The get appointment message sent by the user to retrieve a previously sent appointment from the tower.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GetAppointment {
     pub locator: Locator,
     pub signature: String,
 }
 
 /// The appointment data message sent by the tower after a get appointment message.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AppointmentData {
     pub locator: Locator,
     pub encrypted_blob: Vec<u8>,
 }
 
 /// The tracker data message sent by the tower when the requested appointment has been acted upon.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TrackerData {
     pub dispute_txid: Txid,
     pub penalty_txid: Txid,
@@ -85,19 +86,19 @@ pub struct TrackerData {
 
 /// The appointment not found message sent by the tower in response to a get appointment message
 /// whose locator didn't match any known appointment.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AppointmentNotFound {
     pub locator: Locator,
 }
 
 /// The get subscription info message (a TEOS custom message, not a bolt13 one).
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GetSubscriptionInfo {
     pub signature: String,
 }
 
 /// The subscription info message sent by the tower in response to get subscription info message.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SubscriptionInfo {
     pub available_slots: u32,
     pub subscription_expiry: u32,
@@ -189,7 +190,7 @@ set_msg_type!(AppointmentNotFound, 48864);
 set_msg_type!(GetSubscriptionInfo, 48865);
 set_msg_type!(SubscriptionInfo, 48867);
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum TowerMessage {
     // Register messages
     Register(Register),

--- a/teos-common/src/lightning/messages.rs
+++ b/teos-common/src/lightning/messages.rs
@@ -258,10 +258,10 @@ mod tests {
     fn test_msg<T: Debug + Readable + Writeable + PartialEq>(msg: T) {
         // Get a writer and write the message to it.
         let mut stream = TestVecWriter(Vec::new());
-        msg.write(&mut stream).ok().unwrap();
+        msg.write(&mut stream).unwrap();
         // Create a reader out of the written buffer.
         let mut stream = Cursor::new(stream.0);
-        let read_msg: T = Readable::read(&mut stream).ok().unwrap();
+        let read_msg: T = Readable::read(&mut stream).unwrap();
         // Assert the serialized then deserialized message is the same as the original one.
         assert_eq!(msg, read_msg);
     }

--- a/teos-common/src/lightning/mod.rs
+++ b/teos-common/src/lightning/mod.rs
@@ -1,0 +1,3 @@
+pub mod messages;
+mod ser_macros;
+mod ser_utils;

--- a/teos-common/src/lightning/mod.rs
+++ b/teos-common/src/lightning/mod.rs
@@ -1,3 +1,4 @@
+mod convert;
 pub mod messages;
 mod ser_macros;
 mod ser_utils;

--- a/teos-common/src/lightning/ser_macros.rs
+++ b/teos-common/src/lightning/ser_macros.rs
@@ -8,12 +8,12 @@
 */
 
 macro_rules! encode_tlv {
-    ($stream: expr, $type: expr, $field: expr, opt) => {
+    ($stream:expr, $type:expr, $field:expr, opt) => {
         if let Some(ref field) = $field {
             ser_macros::encode_tlv!($stream, $type, field);
         }
     };
-    ($stream: expr, $type: expr, $field: expr, vec) => {
+    ($stream:expr, $type:expr, $field:expr, vec) => {
         // Don't write the vector if it's empty.
         if !$field.is_empty() {
             // We can't just pass `$field` since this will move it out of the struct we are implementing
@@ -22,13 +22,13 @@ macro_rules! encode_tlv {
             ser_macros::encode_tlv!($stream, $type, lightning_vec);
         }
     };
-    ($stream: expr, $type: expr, $field: expr, opt_str) => {
+    ($stream:expr, $type:expr, $field:expr, opt_str) => {
         if let Some(ref field) = $field {
             let lightning_str = ser_utils::LightningVecWriter(field.as_bytes());
             ser_macros::encode_tlv!($stream, $type, lightning_str);
         }
     };
-    ($stream: expr, $type: expr, $field: expr) => {
+    ($stream:expr, $type:expr, $field:expr) => {
         BigSize($type).write($stream)?;
         BigSize($field.serialized_length() as u64).write($stream)?;
         $field.write($stream)?;
@@ -36,7 +36,7 @@ macro_rules! encode_tlv {
 }
 
 macro_rules! encode_tlv_stream {
-    ($stream: expr, {$(($type: expr, $field: expr, $fieldty: tt)),* $(,)*}) => { {
+    ($stream:expr, {$(($type:expr, $field:expr, $fieldty:tt)),* $(,)*}) => { {
         #[allow(unused_imports)]
         use {
             lightning::util::ser::BigSize,
@@ -62,14 +62,14 @@ macro_rules! encode_tlv_stream {
 }
 
 macro_rules! decode_tlv {
-    ($reader: expr, $field: ident, opt) => {
+    ($reader:expr, $field:ident, opt) => {
         $field = Some(Readable::read(&mut $reader)?);
     };
-    ($reader: expr, $field: ident, vec) => {
+    ($reader:expr, $field:ident, vec) => {
         let lightning_vec = ser_utils::LightningVecReader::read(&mut $reader)?;
         $field = lightning_vec.0;
     };
-    ($reader: expr, $field: ident, opt_str) => {
+    ($reader:expr, $field:ident, opt_str) => {
         let lightning_str = ser_utils::LightningVecReader::read(&mut $reader)?;
         let inner_str =
             String::from_utf8(lightning_str.0).map_err(|_| DecodeError::InvalidValue)?;
@@ -78,7 +78,7 @@ macro_rules! decode_tlv {
 }
 
 macro_rules! decode_tlv_stream {
-    ($stream: expr, {$(($type: expr, $field: ident, $fieldty: tt)),* $(,)*}) => { {
+    ($stream:expr, {$(($type:expr, $field:ident, $fieldty:tt)),* $(,)*}) => { {
         #[allow(unused_imports)]
         use {
             lightning::ln::msgs::DecodeError,
@@ -137,19 +137,19 @@ macro_rules! decode_tlv_stream {
 }
 
 macro_rules! init_tlv_field_var {
-    ($field: ident, opt) => {
+    ($field:ident, opt) => {
         let mut $field = None;
     };
-    ($field: ident, vec) => {
+    ($field:ident, vec) => {
         let mut $field = Vec::new();
     };
-    ($field: ident, opt_str) => {
+    ($field:ident, opt_str) => {
         let mut $field = None;
     };
 }
 
 macro_rules! impl_writeable_msg {
-    ($st: ty, {$($field: ident),* $(,)*}, {$(($type: expr, $tlvfield: ident, $fieldty: tt)),* $(,)*}) => {
+    ($st:ty, {$($field:ident),* $(,)*}, {$(($type:expr, $tlvfield:ident, $fieldty:tt)),* $(,)*}) => {
         impl lightning::util::ser::Writeable for $st {
             fn write<W: lightning::util::ser::Writer>(&self, w: &mut W) -> Result<(), lightning::io::Error> {
                 $(self.$field.write(w)?;)*
@@ -182,7 +182,7 @@ macro_rules! impl_writeable_msg {
 }
 
 macro_rules! set_msg_type {
-    ($st: ty, $type: expr) => {
+    ($st:ty, $type:expr) => {
         impl $crate::lightning::ser_utils::Type for $st {
             const TYPE: u16 = $type;
         }
@@ -211,7 +211,7 @@ mod tests {
     use lightning::util::ser::{BigSize, Readable, Writeable};
 
     macro_rules! encode_decode_tlv {
-        ($typ: expr, $field: expr, $fieldty: tt) => {{
+        ($typ:expr, $field:expr, $fieldty:tt) => {{
             // Encode the TLV to a stream.
             let mut stream = ser_utils::TestVecWriter(Vec::new());
             encode_tlv!(&mut stream, $typ, $field, $fieldty);
@@ -242,7 +242,7 @@ mod tests {
     }
 
     macro_rules! test_encode_decode_tlv {
-        ($typ: expr, $len: expr, $val: expr, $fieldty: tt) => {
+        ($typ:expr, $len:expr, $val:expr, $fieldty:tt) => {
             let (typ, len, val) = encode_decode_tlv!($typ, $val, $fieldty)?;
             assert_eq!($typ as u64, typ, "Invalid TLV type");
             assert_eq!($len as u64, len, "Invalid TLV length");
@@ -251,7 +251,7 @@ mod tests {
     }
 
     macro_rules! test_opt_ranged_type {
-        ($type: ident, $expected_len: expr) => {
+        ($type:ident, $expected_len:expr) => {
             // This will try some values in the range of `$type`.
             for i in ($type::MIN..$type::MAX)
                 .step_by(($type::MAX / 4 + 1) as usize)
@@ -302,7 +302,7 @@ mod tests {
     }
 
     macro_rules! encode_decode_tlv_stream {
-        ({$(($type: expr, $field_name: ident, $fieldty: tt)),* $(,)*}) => {{
+        ({$(($type:expr, $field_name:ident, $fieldty:tt)),* $(,)*}) => {{
             // Encode the TLVs to a stream.
             let mut stream = ser_utils::TestVecWriter(Vec::new());
             encode_tlv_stream!(&mut stream, {$(($type, $field_name, $fieldty)),*});
@@ -315,7 +315,7 @@ mod tests {
     }
 
     macro_rules! test_encode_decode_tlv_stream {
-        ({$(($type: expr, $field_name: ident, $field: expr, $fieldty: tt)),* $(,)*}) => {
+        ({$(($type:expr, $field_name:ident, $field:expr, $fieldty:tt)),* $(,)*}) => {
             let original_stream = ($($field),*);
             let decoded_stream = {
                 $(let $field_name = $field;)*
@@ -326,7 +326,7 @@ mod tests {
     }
 
     macro_rules! test_encode_decode_tlv_stream_should_panic {
-        ($args: tt) => {
+        ($args:tt) => {
             // Allow unreachable patterns which happen when we have some non-unique tlv types.
             #[allow(unreachable_patterns)]
             // Runs `test_encode_decode_tlv_stream` inside a closure so that we don't need to

--- a/teos-common/src/lightning/ser_macros.rs
+++ b/teos-common/src/lightning/ser_macros.rs
@@ -198,3 +198,193 @@ pub(super) use init_tlv_field_var;
 
 pub(super) use impl_writeable_msg;
 pub(super) use set_msg_type;
+
+#[cfg(test)]
+mod tests {
+    use crate::appointment::{Locator, LOCATOR_LEN};
+    use crate::lightning::ser_utils::Type;
+    use crate::lightning::{ser_macros, ser_utils};
+    use lightning::io;
+    use lightning::ln::msgs::DecodeError;
+    use lightning::util::ser::{BigSize, Readable, Writeable};
+
+    macro_rules! encode_decode_tlv {
+        ($typ: expr, $field: expr, $fieldty: tt) => {{
+            // Encode the TLV to a stream.
+            let mut stream = ser_utils::TestVecWriter(Vec::new());
+            encode_tlv!(&mut stream, $typ, $field, $fieldty);
+            // Get a reader with the writer's buffer.
+            let mut cursor = io::Cursor::new(stream.0);
+            let mut stream = ser_utils::ReadTrackingReader::new(&mut cursor);
+            init_tlv_field_var!(read_field, $fieldty);
+            #[allow(unreachable_code)]
+            if false {
+                unreachable!();
+                // This assignment will let the compiler infer the type of `read_field`.
+                read_field = $field;
+            }
+            // Try to read from the stream. Note that the stream might be empty if `$field`
+            // carried no info to be written in the first place.
+            let read_typ_result = BigSize::read(&mut stream);
+            if let Ok(read_typ) = read_typ_result {
+                let read_len = BigSize::read(&mut stream)?;
+                let mut stream = ser_utils::FixedLengthReader::new(&mut cursor, read_len.0);
+                decode_tlv!(stream, read_field, $fieldty);
+                Ok((read_typ.0, read_len.0, read_field))
+            } else if !stream.have_read {
+                Ok(($typ, 0, read_field))
+            } else {
+                Err(read_typ_result.err().unwrap())
+            }
+        }};
+    }
+
+    macro_rules! test_encode_decode_tlv {
+        ($typ: expr, $len: expr, $val: expr, $fieldty: tt) => {
+            let (typ, len, val) = encode_decode_tlv!($typ, $val, $fieldty)?;
+            assert_eq!($typ as u64, typ, "Invalid TLV type");
+            assert_eq!($len as u64, len, "Invalid TLV length");
+            assert_eq!($val, val, "Invalid TLV value");
+        };
+    }
+
+    macro_rules! test_opt_ranged_type {
+        ($type: ident, $expected_len: expr) => {
+            // This will try some values in the range of `$type`.
+            for i in ($type::MIN..$type::MAX)
+                .step_by(($type::MAX / 4 + 1) as usize)
+                .chain(vec![$type::MAX])
+            {
+                test_encode_decode_tlv!(i as u64, $expected_len, Some(i), opt);
+            }
+        };
+    }
+
+    #[test]
+    fn test_encode_decode_tlv() -> Result<(), DecodeError> {
+        // All the Nones and empty vectors should have a length of zero.
+        test_encode_decode_tlv!(1, 0, Option::<u8>::None, opt);
+        test_encode_decode_tlv!(1, 0, Option::<u16>::None, opt);
+        test_encode_decode_tlv!(1, 0, Option::<u32>::None, opt);
+        test_encode_decode_tlv!(1, 0, Option::<u64>::None, opt);
+        test_encode_decode_tlv!(1, 0, Option::<String>::None, opt);
+        let v: Vec<u8> = Vec::new();
+        test_encode_decode_tlv!(1, 0, v, vec);
+        let v: Vec<Locator> = Vec::new();
+        test_encode_decode_tlv!(1, 0, v, vec);
+        let v: Vec<String> = Vec::new();
+        test_encode_decode_tlv!(1, 0, v, vec);
+
+        // Non-None primitives should have their in-memory byte length as follows.
+        test_opt_ranged_type!(u8, 1);
+        test_opt_ranged_type!(u16, 2);
+        test_opt_ranged_type!(u32, 4);
+        test_opt_ranged_type!(u64, 8);
+
+        // Other types.
+        let s = Some(String::from("teos"));
+        test_encode_decode_tlv!(1, s.as_ref().unwrap().len() + 2, s, opt);
+        test_encode_decode_tlv!(1, s.as_ref().unwrap().len(), s, opt_str);
+
+        let v = vec![1_u8, 2, 3, 6];
+        test_encode_decode_tlv!(1, v.len(), v, vec);
+
+        let l = ser_utils::get_random_locator();
+        let v = vec![l; 5];
+        test_encode_decode_tlv!(1, v.len() * LOCATOR_LEN, v, vec);
+
+        Ok(())
+    }
+
+    macro_rules! encode_decode_tlv_stream {
+        ({$(($type: expr, $field_name: ident, $fieldty: tt)),* $(,)*}) => {{
+            // Encode the TLVs to a stream.
+            let mut stream = ser_utils::TestVecWriter(Vec::new());
+            encode_tlv_stream!(&mut stream, {$(($type, $field_name, $fieldty)),*});
+            // Re-initialize the fields to their default values before decoding.
+            $(init_tlv_field_var!($field_name, $fieldty);)*
+            // Decode with a reader with the writer's buffer.
+            decode_tlv_stream!(io::Cursor::new(stream.0), {$(($type, $field_name, $fieldty)),*});
+            ($($field_name),*)
+        }};
+    }
+
+    macro_rules! test_encode_decode_tlv_stream {
+        ({$(($type: expr, $field_name: ident, $field: expr, $fieldty: tt)),* $(,)*}) => {
+            let original_stream = ($($field),*);
+            #[allow(unused_assignments)]
+            let decoded_stream = {
+                // Initialize the fields we will read from. An unused_assignment happens here.
+                $(init_tlv_field_var!($field_name, $fieldty);)*
+                $($field_name = $field;)*
+                encode_decode_tlv_stream!({$(($type, $field_name, $fieldty)),*})
+            };
+            assert_eq!(original_stream, decoded_stream, "The decoded stream doesn't match the original one");
+        };
+    }
+
+    macro_rules! test_encode_decode_tlv_stream_should_panic {
+        ($args: tt) => {
+            // Allow unreachable patterns which happen when we have some non-unique tlv types.
+            #[allow(unreachable_patterns)]
+            // Runs `test_encode_decode_tlv_stream` inside a closure so that we don't need to
+            // return a `Result<(), DecodeError` from the test functions.
+            // `should_panic` tests must not return anything.
+            (|| {
+                test_encode_decode_tlv_stream!($args);
+                Ok(())
+            })()
+            // Unwrap to panic on error.
+            .unwrap();
+        };
+    }
+
+    #[test]
+    fn test_encode_decode_tlv_stream() -> Result<(), DecodeError> {
+        test_encode_decode_tlv_stream!({
+            (0, a, Option::<u32>::None, opt),
+            (1, b, Some(3_u32), opt),
+            (2, c, Some(String::from("teos")), opt),
+            (31, d, Some(String::from("teos")), opt_str),
+        });
+
+        let l = ser_utils::get_random_locator();
+        test_encode_decode_tlv_stream!({
+            (12, a, vec![1_u32, 2, 3], vec),
+            (24, b, Some(vec![1_u8, 2, 3]), opt),
+            (31, c, vec!["one".to_owned(), "two".to_owned(), "3".to_owned()], vec),
+            (59, d, Vec::<u32>::new(), vec),
+            (78, e, vec![l; 4], vec),
+        });
+
+        Ok(())
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_encode_decode_tlv_stream_decreasing_type() {
+        test_encode_decode_tlv_stream_should_panic!({
+            (0, a, Some(0_u8), opt),
+            (2, b, Some(1_u32), opt),
+            (1, c, Vec::<u8>::new(), vec),
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_encode_decode_tlv_stream_non_increasing_type() {
+        test_encode_decode_tlv_stream_should_panic!({
+            (0, a, Some(0_u8), opt),
+            (1, b, Some(1_u32), opt),
+            (1, c, Vec::<u8>::new(), vec),
+        });
+    }
+
+    #[test]
+    fn test_set_msg_type() {
+        struct Test1;
+        set_msg_type!(Test1, 10);
+
+        assert_eq!(Test1::TYPE, 10);
+    }
+}

--- a/teos-common/src/lightning/ser_macros.rs
+++ b/teos-common/src/lightning/ser_macros.rs
@@ -1,0 +1,200 @@
+//! A module containing some trait implementation macros to avoid repetition.
+//! Most of this file is taken/inspired from [here](https://github.com/lightningdevkit/rust-lightning/blob/3676a056c85f54347e7e079e913317a79e26a2ae/lightning/src/util/ser_macros.rs).
+
+/* This file is licensed under either of
+ *  Apache License, Version 2.0, (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or
+ *  MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT)
+ * at your option.
+*/
+
+macro_rules! encode_tlv {
+    ($stream: expr, $type: expr, $field: expr, opt) => {
+        if let Some(ref field) = $field {
+            ser_macros::encode_tlv!($stream, $type, field);
+        }
+    };
+    ($stream: expr, $type: expr, $field: expr, vec) => {
+        // Don't write the vector if it's empty.
+        if !$field.is_empty() {
+            // We can't just pass `$field` since this will move it out of the struct we are implementing
+            // this serialization for (but we could have cloned). That's why we pass a reference to it.
+            let lightning_vec = ser_utils::LightningVecWriter(&$field);
+            ser_macros::encode_tlv!($stream, $type, lightning_vec);
+        }
+    };
+    ($stream: expr, $type: expr, $field: expr, opt_str) => {
+        if let Some(ref field) = $field {
+            let lightning_str = ser_utils::LightningVecWriter(field.as_bytes());
+            ser_macros::encode_tlv!($stream, $type, lightning_str);
+        }
+    };
+    ($stream: expr, $type: expr, $field: expr) => {
+        BigSize($type).write($stream)?;
+        BigSize($field.serialized_length() as u64).write($stream)?;
+        $field.write($stream)?;
+    };
+}
+
+macro_rules! encode_tlv_stream {
+    ($stream: expr, {$(($type: expr, $field: expr, $fieldty: tt)),* $(,)*}) => { {
+        #[allow(unused_imports)]
+        use {
+            lightning::util::ser::BigSize,
+            $crate::lightning::{ser_macros, ser_utils},
+        };
+
+        $(
+            ser_macros::encode_tlv!($stream, $type, $field, $fieldty);
+        )*
+
+        #[allow(unused_mut, unused_variables, unused_assignments, unused_comparisons)]
+        #[cfg(debug_assertions)]
+        {
+            let mut last_seen: Option<u64> = None;
+            $(
+                if let Some(t) = last_seen {
+                    debug_assert!(t < $type, "{} <= {}; TLV types must be strictly increasing", $type, t);
+                }
+                last_seen = Some($type);
+            )*
+        }
+    } }
+}
+
+macro_rules! decode_tlv {
+    ($reader: expr, $field: ident, opt) => {
+        $field = Some(Readable::read(&mut $reader)?);
+    };
+    ($reader: expr, $field: ident, vec) => {
+        let lightning_vec = ser_utils::LightningVecReader::read(&mut $reader)?;
+        $field = lightning_vec.0;
+    };
+    ($reader: expr, $field: ident, opt_str) => {
+        let lightning_str = ser_utils::LightningVecReader::read(&mut $reader)?;
+        let inner_str =
+            String::from_utf8(lightning_str.0).map_err(|_| DecodeError::InvalidValue)?;
+        $field = Some(inner_str);
+    };
+}
+
+macro_rules! decode_tlv_stream {
+    ($stream: expr, {$(($type: expr, $field: ident, $fieldty: tt)),* $(,)*}) => { {
+        #[allow(unused_imports)]
+        use {
+            lightning::ln::msgs::DecodeError,
+            lightning::util::ser::{BigSize, Readable},
+            $crate::lightning::{ser_macros, ser_utils},
+        };
+
+        let mut last_seen_type: Option<u64> = None;
+        let mut stream_ref = $stream;
+
+        loop {
+            // First decode the type of this TLV:
+            let typ: BigSize = {
+                let mut tracking_reader = ser_utils::ReadTrackingReader::new(&mut stream_ref);
+                match Readable::read(&mut tracking_reader) {
+                    Err(DecodeError::ShortRead) => {
+                        if !tracking_reader.have_read {
+                            break;
+                        } else {
+                            return Err(DecodeError::ShortRead);
+                        }
+                    },
+                    Err(e) => return Err(e),
+                    Ok(t) => t,
+                }
+            };
+
+            // Types must be unique and monotonically increasing:
+            match last_seen_type {
+                Some(t) if typ.0 <= t => {
+                    return Err(DecodeError::InvalidValue);
+                },
+                _ => {},
+            }
+            last_seen_type = Some(typ.0);
+
+            // Finally, read the length and value itself:
+            let length: BigSize = Readable::read(&mut stream_ref)?;
+            let mut s = ser_utils::FixedLengthReader::new(&mut stream_ref, length.0);
+            match typ.0 {
+                $($type => {
+                    ser_macros::decode_tlv!(s, $field, $fieldty);
+                    if s.bytes_remain() {
+                        s.eat_remaining()?; // Return ShortRead if there's actually not enough bytes
+                        return Err(DecodeError::InvalidValue);
+                    }
+                },)*
+                x if x % 2 == 0 => {
+                    return Err(DecodeError::UnknownRequiredFeature);
+                },
+                _ => {},
+            }
+            s.eat_remaining()?;
+        }
+    } }
+}
+
+macro_rules! init_tlv_field_var {
+    ($field: ident, opt) => {
+        let mut $field = None;
+    };
+    ($field: ident, vec) => {
+        let mut $field = Vec::new();
+    };
+    ($field: ident, opt_str) => {
+        let mut $field = None;
+    };
+}
+
+macro_rules! impl_writeable_msg {
+    ($st: ty, {$($field: ident),* $(,)*}, {$(($type: expr, $tlvfield: ident, $fieldty: tt)),* $(,)*}) => {
+        impl lightning::util::ser::Writeable for $st {
+            fn write<W: lightning::util::ser::Writer>(&self, w: &mut W) -> Result<(), lightning::io::Error> {
+                $(self.$field.write(w)?;)*
+                $crate::lightning::ser_macros::encode_tlv_stream!(w, {$(($type, self.$tlvfield, $fieldty)),*});
+                Ok(())
+            }
+        }
+
+        impl lightning::util::ser::Readable for $st {
+            fn read<R: lightning::io::Read>(r: &mut R) -> Result<Self, lightning::ln::msgs::DecodeError> {
+                $(let $field = lightning::util::ser::Readable::read(r)?;)*
+                $($crate::lightning::ser_macros::init_tlv_field_var!($tlvfield, $fieldty);)*
+                $crate::lightning::ser_macros::decode_tlv_stream!(r, {$(($type, $tlvfield, $fieldty)),*});
+                Ok(Self {
+                    $($field),*,
+                    $($tlvfield),*
+                })
+            }
+        }
+
+        #[cfg(test)]
+        impl std::cmp::PartialEq for $st {
+            fn eq(&self, other: &Self) -> bool {
+                true
+                $(&& self.$field == other.$field)*
+                $(&& self.$tlvfield == other.$tlvfield)*
+            }
+        }
+    }
+}
+
+macro_rules! set_msg_type {
+    ($st: ty, $type: expr) => {
+        impl $crate::lightning::ser_utils::Type for $st {
+            const TYPE: u16 = $type;
+        }
+    };
+}
+
+// Macros used by `impl_writeable_msg`.
+pub(super) use decode_tlv;
+pub(super) use decode_tlv_stream;
+pub(super) use encode_tlv;
+pub(super) use encode_tlv_stream;
+pub(super) use init_tlv_field_var;
+
+pub(super) use impl_writeable_msg;
+pub(super) use set_msg_type;

--- a/teos-common/src/lightning/ser_utils.rs
+++ b/teos-common/src/lightning/ser_utils.rs
@@ -170,3 +170,31 @@ impl<R: Read> Read for ReadTrackingReader<R> {
         }
     }
 }
+
+#[cfg(test)]
+mod test_utils {
+    use crate::appointment::{Locator, LOCATOR_LEN};
+    use crate::cryptography::get_random_bytes;
+    use bitcoin::hashes::Hash;
+    use bitcoin::Txid;
+    pub use lightning::util::test_utils::TestVecWriter;
+
+    pub fn get_random_locator() -> Locator {
+        let bytes = get_random_bytes(LOCATOR_LEN);
+        Locator::from_slice(&bytes).unwrap()
+    }
+
+    pub fn get_random_txid() -> Txid {
+        let bytes = get_random_bytes(32);
+        Txid::from_slice(&bytes).unwrap()
+    }
+
+    #[allow(dead_code)]
+    pub fn get_random_string(size: usize) -> String {
+        let bytes = get_random_bytes(size);
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+}
+
+#[cfg(test)]
+pub(super) use test_utils::*;

--- a/teos-common/src/lightning/ser_utils.rs
+++ b/teos-common/src/lightning/ser_utils.rs
@@ -1,0 +1,172 @@
+//! A helper module containing some lightning messages serialization stuff.
+//! Most of this file is taken/inspired from [here](https://github.com/lightningdevkit/rust-lightning/blob/3676a056c85f54347e7e079e913317a79e26a2ae/lightning/src/util/ser.rs).
+
+/* This file is licensed under either of
+ *  Apache License, Version 2.0, (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or
+ *  MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT)
+ * at your option.
+*/
+
+use crate::appointment::{Locator, LOCATOR_LEN};
+
+use lightning::io::{copy, sink, Error, Read};
+use lightning::ln::msgs::DecodeError;
+use lightning::util::ser::{MaybeReadable, Readable, Writeable, Writer};
+
+/// A trait that associates a u16 [`Type::TYPE`] constant with a lightning message.
+pub trait Type {
+    /// The type identifying the message payload.
+    const TYPE: u16;
+}
+
+// Deserialization for a Locator inside a lightning message.
+impl Readable for Locator {
+    fn read<R: Read>(reader: &mut R) -> Result<Self, DecodeError> {
+        let mut buf = [0; LOCATOR_LEN];
+        reader.read_exact(&mut buf)?;
+        let locator = Self::from_slice(&buf).map_err(|_| DecodeError::InvalidValue)?;
+        Ok(locator)
+    }
+}
+
+// Serialization for a Locator inside a lighting message.
+impl Writeable for Locator {
+    fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+        writer.write_all(&self.to_vec())?;
+        Ok(())
+    }
+}
+
+/// A read wrapper around a vector inside a lightning message.
+/// This wrapper mainly exists because we cannot implement LDK's (de)serialization traits
+/// for Vec (since neither the traits nor Vec are defined in our crate (the orphan rule)).
+///
+/// [`Readable`] implementation for this struct assumes that there is no length prefix.
+/// It will read the vector until there are no more items in the stream (Don't use with non-TLV field).
+pub(super) struct LightningVecReader<T>(pub Vec<T>);
+
+// Deserialization for a vector of items inside a lightning message.
+impl<T: MaybeReadable> Readable for LightningVecReader<T> {
+    #[inline]
+    fn read<R: Read>(mut reader: &mut R) -> Result<Self, DecodeError> {
+        let mut values = Vec::new();
+        loop {
+            let mut track_read = ReadTrackingReader::new(&mut reader);
+            match MaybeReadable::read(&mut track_read) {
+                Ok(Some(v)) => {
+                    values.push(v);
+                }
+                Ok(None) => {}
+                // If we failed to read any bytes at all, we reached the end of our TLV
+                // stream and have simply exhausted all entries.
+                Err(e) if e == DecodeError::ShortRead && !track_read.have_read => break,
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(Self(values))
+    }
+}
+
+/// A write wrapper around a vector/slice inside a lightning message.
+/// Similar to [`LightningVecReader`] but the inner vector is a slice reference to avoid cloning.
+///
+/// Note that we don't prefix the vector/slice with its length when serializing it, that's because this struct
+/// is used in TLV streams which already has a BigSize length prefix (Don't use with non-TLV field).
+pub(super) struct LightningVecWriter<'a, T>(pub &'a [T]);
+
+// Serialization for a vector of items inside a lighting message.
+impl<'a, T: Writeable> Writeable for LightningVecWriter<'a, T> {
+    #[inline]
+    fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+        for item in self.0.iter() {
+            item.write(writer)?;
+        }
+        Ok(())
+    }
+}
+
+/// Essentially std::io::Take but a bit simpler and with a method to walk the underlying stream
+/// forward to ensure we always consume exactly the fixed length specified.
+pub(super) struct FixedLengthReader<R: Read> {
+    read: R,
+    bytes_read: u64,
+    total_bytes: u64,
+}
+
+impl<R: Read> FixedLengthReader<R> {
+    /// Returns a new FixedLengthReader.
+    pub fn new(read: R, total_bytes: u64) -> Self {
+        Self {
+            read,
+            bytes_read: 0,
+            total_bytes,
+        }
+    }
+
+    /// Returns whether there are remaining bytes or not.
+    #[inline]
+    pub fn bytes_remain(&mut self) -> bool {
+        self.bytes_read != self.total_bytes
+    }
+
+    /// Consume the remaining bytes.
+    #[inline]
+    pub fn eat_remaining(&mut self) -> Result<(), DecodeError> {
+        copy(self, &mut sink()).unwrap();
+        if self.bytes_read != self.total_bytes {
+            Err(DecodeError::ShortRead)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<R: Read> Read for FixedLengthReader<R> {
+    #[inline]
+    fn read(&mut self, dest: &mut [u8]) -> Result<usize, Error> {
+        if self.total_bytes == self.bytes_read {
+            Ok(0)
+        } else {
+            let read_len = core::cmp::min(dest.len() as u64, self.total_bytes - self.bytes_read);
+            match self.read.read(&mut dest[0..(read_len as usize)]) {
+                Ok(v) => {
+                    self.bytes_read += v as u64;
+                    Ok(v)
+                }
+                Err(e) => Err(e),
+            }
+        }
+    }
+}
+
+/// A Read which tracks whether any bytes have been read at all. This allows us to distinguish
+/// between "EOF reached before we started" and "EOF reached mid-read".
+pub(super) struct ReadTrackingReader<R: Read> {
+    read: R,
+    /// Tells whether we have read from this reader or not yet.
+    pub have_read: bool,
+}
+
+impl<R: Read> ReadTrackingReader<R> {
+    /// Returns a new ReadTrackingReader.
+    pub fn new(read: R) -> Self {
+        Self {
+            read,
+            have_read: false,
+        }
+    }
+}
+
+impl<R: Read> Read for ReadTrackingReader<R> {
+    #[inline]
+    fn read(&mut self, dest: &mut [u8]) -> Result<usize, Error> {
+        match self.read.read(dest) {
+            Ok(0) => Ok(0),
+            Ok(len) => {
+                self.have_read = true;
+                Ok(len)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/teos-common/src/lightning/ser_utils.rs
+++ b/teos-common/src/lightning/ser_utils.rs
@@ -26,8 +26,7 @@ impl Readable for Locator {
     fn read<R: Read>(reader: &mut R) -> Result<Self, DecodeError> {
         let mut buf = [0; LOCATOR_LEN];
         reader.read_exact(&mut buf)?;
-        let locator = Self::from_slice(&buf).map_err(|_| DecodeError::InvalidValue)?;
-        Ok(locator)
+        Self::from_slice(&buf).map_err(|_| DecodeError::InvalidValue)
     }
 }
 
@@ -43,8 +42,7 @@ impl Readable for UserId {
     fn read<R: Read>(reader: &mut R) -> Result<Self, DecodeError> {
         let mut buf = [0; PUBLIC_KEY_SIZE];
         reader.read_exact(&mut buf)?;
-        let user_id = Self::from_slice(&buf).map_err(|_| DecodeError::InvalidValue)?;
-        Ok(user_id)
+        Self::from_slice(&buf).map_err(|_| DecodeError::InvalidValue)
     }
 }
 
@@ -77,7 +75,7 @@ impl<T: MaybeReadable> Readable for LightningVecReader<T> {
                 Ok(None) => {}
                 // If we failed to read any bytes at all, we reached the end of our TLV
                 // stream and have simply exhausted all entries.
-                Err(e) if e == DecodeError::ShortRead && !track_read.have_read => break,
+                Err(ref e) if e == &DecodeError::ShortRead && !track_read.have_read => break,
                 Err(e) => return Err(e),
             }
         }

--- a/teos-common/src/lightning/ser_utils.rs
+++ b/teos-common/src/lightning/ser_utils.rs
@@ -8,7 +8,9 @@
 */
 
 use crate::appointment::{Locator, LOCATOR_LEN};
+use crate::UserId;
 
+use bitcoin::secp256k1::constants::PUBLIC_KEY_SIZE;
 use lightning::io::{copy, sink, Error, ErrorKind, Read};
 use lightning::ln::msgs::DecodeError;
 use lightning::util::ser::{MaybeReadable, Readable, Writeable, Writer};
@@ -33,6 +35,23 @@ impl Readable for Locator {
 impl Writeable for Locator {
     fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
         writer.write_all(&self.to_vec())
+    }
+}
+
+// Deserialization for a UserId inside a lightning message.
+impl Readable for UserId {
+    fn read<R: Read>(reader: &mut R) -> Result<Self, DecodeError> {
+        let mut buf = [0; PUBLIC_KEY_SIZE];
+        reader.read_exact(&mut buf)?;
+        let user_id = Self::from_slice(&buf).map_err(|_| DecodeError::InvalidValue)?;
+        Ok(user_id)
+    }
+}
+
+// Serialization for a UserId inside a lighting message.
+impl Writeable for UserId {
+    fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+        self.0.write(writer)
     }
 }
 

--- a/teos/Cargo.toml
+++ b/teos/Cargo.toml
@@ -47,6 +47,7 @@ teos-common = { path = "../teos-common" }
 tonic-build = "0.6"
 
 [dev-dependencies]
+futures = "0.3.21"
 jsonrpc-http-server = "17.1.0"
 rand = "0.8.4"
 tempdir = "0.3.7"

--- a/teos/src/api/lightning.rs
+++ b/teos/src/api/lightning.rs
@@ -1,0 +1,191 @@
+//! Watchtower's Lightning interface.
+
+use bitcoin::secp256k1::PublicKey;
+use tokio::runtime;
+
+use crate::protos::public_tower_services_client::PublicTowerServicesClient;
+use tonic::transport::Channel;
+use tonic::Code;
+
+use lightning::io;
+use lightning::ln::msgs::{DecodeError, ErrorAction, LightningError, WarningMessage};
+use lightning::ln::peer_handler::CustomMessageHandler;
+use lightning::ln::wire::CustomMessageReader;
+use lightning::util::logger;
+use lightning::util::ser::Readable;
+
+use std::mem;
+use std::sync::Mutex;
+
+use teos_common::lightning::messages::*;
+use teos_common::protos as common_msgs;
+
+/// A helper that returns an [`Err(LightningError)`] with the specified warning message.
+fn warn_peer<T>(msg_to_peer: &str, msg_to_log: &str) -> Result<T, LightningError> {
+    Err(LightningError {
+        err: msg_to_log.to_owned(),
+        action: ErrorAction::SendWarningMessage {
+            msg: WarningMessage {
+                // Zeros for channel id tells that the warning isn't channel specific.
+                channel_id: [0; 32],
+                data: msg_to_peer.to_owned(),
+            },
+            log_level: logger::Level::Warn,
+        },
+    })
+}
+
+/// A handler to handle the incoming [`TowerMessage`]s.
+pub struct TowerMessageHandler {
+    /// A queue holding the response messages or errors the tower wants to send to its peers.
+    msg_queue: Mutex<Vec<(PublicKey, TowerMessage)>>,
+    // TODO: Will it make more sense using the watcher interface instead of the gRPC?
+    // since the watcher interface is not async and it does provide richer error codes.
+    /// A connection to the tower's internal gRPC API.
+    grpc_conn: PublicTowerServicesClient<Channel>,
+    /// A tokio runtime handle to run gRPC async calls on.
+    handle: runtime::Handle,
+}
+
+impl TowerMessageHandler {
+    fn new(grpc_conn: PublicTowerServicesClient<Channel>, handle: runtime::Handle) -> Self {
+        Self {
+            msg_queue: Mutex::new(Vec::new()),
+            grpc_conn,
+            handle,
+        }
+    }
+
+    fn handle_tower_message(
+        &self,
+        msg: TowerMessage,
+        peer: &PublicKey,
+    ) -> Result<TowerMessage, LightningError> {
+        log::info!("Received {:?} from {}", msg, peer);
+        let mut grpc_conn = self.grpc_conn.clone();
+        match msg {
+            TowerMessage::Register(msg) => {
+                let res = self
+                    .handle
+                    .block_on(grpc_conn.register(common_msgs::RegisterRequest::from(msg)));
+                match res {
+                    Ok(r) => Ok(r.into_inner().into()),
+                    Err(e) => warn_peer(
+                        e.message(),
+                        &format!("Failed registering {} because {}", peer, e.message()),
+                    ),
+                }
+            }
+            TowerMessage::AddUpdateAppointment(msg) => {
+                let res =
+                    self.handle
+                        .block_on(grpc_conn.add_appointment(
+                            common_msgs::AddAppointmentRequest::from(msg.clone()),
+                        ));
+                match res {
+                    Ok(r) => Ok(r.into_inner().into()),
+                    // NOTE: The gRPC interface multiplexes the errors and doesn't let us know what they exactly
+                    // were. Possible errors can be found [here](crate::watcher::AddAppointmentFailure).
+                    Err(e) if e.code() == Code::Unauthenticated => Ok(AppointmentRejected {
+                        locator: msg.locator,
+                        rcode: Code::Unauthenticated as u16,
+                        reason: e.message().into(),
+                    }
+                    .into()),
+                    Err(e) if e.code() == Code::AlreadyExists => Ok(AppointmentRejected {
+                        locator: msg.locator,
+                        rcode: Code::AlreadyExists as u16,
+                        reason: e.message().into(),
+                    }
+                    .into()),
+                    Err(e) => warn_peer(
+                        e.message(),
+                        &format!(
+                            "Failed accepting appointment from {} with locator {}",
+                            peer, msg.locator
+                        ),
+                    ),
+                }
+            }
+            TowerMessage::GetAppointment(msg) => {
+                let res =
+                    self.handle
+                        .block_on(grpc_conn.get_appointment(
+                            common_msgs::GetAppointmentRequest::from(msg.clone()),
+                        ));
+                match res {
+                    Ok(r) => Ok(r.into_inner().into()),
+                    Err(e) if e.code() == Code::NotFound => Ok(AppointmentNotFound {
+                        locator: msg.locator,
+                    }
+                    .into()),
+                    Err(e) => warn_peer(
+                        e.message(),
+                        &format!(
+                            "GetAppointment request from {} failed because {}",
+                            peer,
+                            e.message()
+                        ),
+                    ),
+                }
+            }
+            TowerMessage::GetSubscriptionInfo(msg) => {
+                let res = self.handle.block_on(
+                    grpc_conn
+                        .get_subscription_info(common_msgs::GetSubscriptionInfoRequest::from(msg)),
+                );
+                match res {
+                    Ok(r) => Ok(r.into_inner().into()),
+                    Err(e) => warn_peer(
+                        e.message(),
+                        &format!(
+                            "GetSubscriptionInfo request from {} failed because {}",
+                            peer,
+                            e.message()
+                        ),
+                    ),
+                }
+            }
+            // TODO: DeleteAppointment
+            // TowerMessageHandler as CustomMessageReader won't produce other than the above messages.
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl CustomMessageReader for TowerMessageHandler {
+    type CustomMessage = TowerMessage;
+
+    fn read<R: io::Read>(
+        &self,
+        message_type: u16,
+        buffer: &mut R,
+    ) -> Result<Option<TowerMessage>, DecodeError> {
+        match message_type {
+            Register::TYPE => Ok(Some(Register::read(buffer)?.into())),
+            AddUpdateAppointment::TYPE => Ok(Some(AddUpdateAppointment::read(buffer)?.into())),
+            GetAppointment::TYPE => Ok(Some(GetAppointment::read(buffer)?.into())),
+            GetSubscriptionInfo::TYPE => Ok(Some(GetSubscriptionInfo::read(buffer)?.into())),
+            // Unknown message.
+            _ => Ok(None),
+        }
+    }
+}
+
+impl CustomMessageHandler for TowerMessageHandler {
+    fn handle_custom_message(
+        &self,
+        msg: TowerMessage,
+        sender_node_id: &PublicKey,
+    ) -> Result<(), LightningError> {
+        self.msg_queue.lock().unwrap().push((
+            *sender_node_id,
+            self.handle_tower_message(msg, sender_node_id)?,
+        ));
+        Ok(())
+    }
+
+    fn get_and_clear_pending_msg(&self) -> Vec<(PublicKey, TowerMessage)> {
+        mem::take(&mut self.msg_queue.lock().unwrap())
+    }
+}

--- a/teos/src/api/lightning.rs
+++ b/teos/src/api/lightning.rs
@@ -1,7 +1,7 @@
 //! Watchtower's Lightning interface.
 
-use bitcoin::secp256k1::PublicKey;
-use tokio::runtime;
+use bitcoin::secp256k1::{PublicKey, SecretKey};
+use triggered::Listener;
 
 use crate::protos::public_tower_services_client::PublicTowerServicesClient;
 use tonic::transport::Channel;
@@ -9,16 +9,33 @@ use tonic::Code;
 
 use lightning::io;
 use lightning::ln::msgs::{DecodeError, ErrorAction, LightningError, WarningMessage};
-use lightning::ln::peer_handler::CustomMessageHandler;
+use lightning::ln::peer_handler::{
+    CustomMessageHandler, ErroringMessageHandler, IgnoringMessageHandler, MessageHandler,
+    PeerManager,
+};
 use lightning::ln::wire::CustomMessageReader;
-use lightning::util::logger;
+use lightning::util::logger::{Level, Logger as LightningLogger, Record};
 use lightning::util::ser::Readable;
 
-use std::mem;
-use std::sync::Mutex;
+use lightning_net_tokio::SocketDescriptor;
 
+use std::convert::TryInto;
+use std::mem;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use teos_common::cryptography::get_random_bytes;
 use teos_common::lightning::messages::*;
 use teos_common::protos as common_msgs;
+
+// FIXME: Check if we can drop some Arcs here.
+type TowerPeerManager = PeerManager<
+    SocketDescriptor,
+    Arc<ErroringMessageHandler>, // No channel message handler
+    Arc<IgnoringMessageHandler>, // No routing message handler
+    Arc<Logger>,
+    Arc<TowerMessageHandler>, // Using our custom message handler
+>;
 
 /// A helper that returns an [`Err(LightningError)`] with the specified warning message.
 fn warn_peer<T>(msg_to_peer: &str, msg_to_log: &str) -> Result<T, LightningError> {
@@ -30,7 +47,7 @@ fn warn_peer<T>(msg_to_peer: &str, msg_to_log: &str) -> Result<T, LightningError
                 channel_id: [0; 32],
                 data: msg_to_peer.to_owned(),
             },
-            log_level: logger::Level::Warn,
+            log_level: Level::Warn,
         },
     })
 }
@@ -41,14 +58,14 @@ pub struct TowerMessageHandler {
     msg_queue: Mutex<Vec<(PublicKey, TowerMessage)>>,
     // TODO: Will it make more sense using the watcher interface instead of the gRPC?
     // since the watcher interface is not async and it does provide richer error codes.
-    /// A connection to the tower's internal gRPC API.
+    /// A connection to the tower's public internal gRPC API.
     grpc_conn: PublicTowerServicesClient<Channel>,
     /// A tokio runtime handle to run gRPC async calls on.
-    handle: runtime::Handle,
+    handle: tokio::runtime::Handle,
 }
 
 impl TowerMessageHandler {
-    fn new(grpc_conn: PublicTowerServicesClient<Channel>, handle: runtime::Handle) -> Self {
+    fn new(grpc_conn: PublicTowerServicesClient<Channel>, handle: tokio::runtime::Handle) -> Self {
         Self {
             msg_queue: Mutex::new(Vec::new()),
             grpc_conn,
@@ -56,100 +73,105 @@ impl TowerMessageHandler {
         }
     }
 
+    /// Handles a tower request message by casting it to a gRPC message and send it to the
+    /// internal API. The API's response is then casted to a tower response and returned.
+    /// The argument `peer` is used for logging purposes only.
     fn handle_tower_message(
         &self,
         msg: TowerMessage,
         peer: &PublicKey,
     ) -> Result<TowerMessage, LightningError> {
-        log::info!("Received {:?} from {}", msg, peer);
-        let mut grpc_conn = self.grpc_conn.clone();
-        match msg {
-            TowerMessage::Register(msg) => {
-                let res = self
-                    .handle
-                    .block_on(grpc_conn.register(common_msgs::RegisterRequest::from(msg)));
-                match res {
-                    Ok(r) => Ok(r.into_inner().into()),
-                    Err(e) => warn_peer(
-                        e.message(),
-                        &format!("Failed registering {} because {}", peer, e.message()),
-                    ),
+        tokio::task::block_in_place(|| {
+            log::info!("Received {:?} from {}", msg, peer);
+            let mut grpc_conn = self.grpc_conn.clone();
+            match msg {
+                TowerMessage::Register(msg) => {
+                    let res = self
+                        .handle
+                        .block_on(grpc_conn.register(common_msgs::RegisterRequest::from(msg)));
+                    match res {
+                        Ok(r) => Ok(r.into_inner().into()),
+                        Err(e) => warn_peer(
+                            e.message(),
+                            &format!("Failed registering {} because {}", peer, e.message()),
+                        ),
+                    }
                 }
-            }
-            TowerMessage::AddUpdateAppointment(msg) => {
-                let res =
-                    self.handle
-                        .block_on(grpc_conn.add_appointment(
+                TowerMessage::AddUpdateAppointment(msg) => {
+                    let res =
+                        self.handle.block_on(grpc_conn.add_appointment(
                             common_msgs::AddAppointmentRequest::from(msg.clone()),
                         ));
-                match res {
-                    Ok(r) => Ok(r.into_inner().into()),
-                    // NOTE: The gRPC interface multiplexes the errors and doesn't let us know what they exactly
-                    // were. Possible errors can be found [here](crate::watcher::AddAppointmentFailure).
-                    Err(e) if e.code() == Code::Unauthenticated => Ok(AppointmentRejected {
-                        locator: msg.locator,
-                        rcode: Code::Unauthenticated as u16,
-                        reason: e.message().into(),
+                    match res {
+                        Ok(r) => Ok(r.into_inner().into()),
+                        // NOTE: The gRPC interface multiplexes the errors and doesn't let us know what they exactly
+                        // were. Possible errors can be found [here](crate::watcher::AddAppointmentFailure).
+                        Err(e) if e.code() == Code::Unauthenticated => Ok(AppointmentRejected {
+                            locator: msg.locator,
+                            rcode: Code::Unauthenticated as u16,
+                            reason: e.message().into(),
+                        }
+                        .into()),
+                        Err(e) if e.code() == Code::AlreadyExists => Ok(AppointmentRejected {
+                            locator: msg.locator,
+                            rcode: Code::AlreadyExists as u16,
+                            reason: e.message().into(),
+                        }
+                        .into()),
+                        Err(e) => {
+                            warn_peer(
+                                e.message(),
+                                &format!(
+                                "Failed accepting appointment from {} with locator {} because {}",
+                                peer, msg.locator, e.message()
+                            ),
+                            )
+                        }
                     }
-                    .into()),
-                    Err(e) if e.code() == Code::AlreadyExists => Ok(AppointmentRejected {
-                        locator: msg.locator,
-                        rcode: Code::AlreadyExists as u16,
-                        reason: e.message().into(),
-                    }
-                    .into()),
-                    Err(e) => warn_peer(
-                        e.message(),
-                        &format!(
-                            "Failed accepting appointment from {} with locator {}",
-                            peer, msg.locator
-                        ),
-                    ),
                 }
-            }
-            TowerMessage::GetAppointment(msg) => {
-                let res =
-                    self.handle
-                        .block_on(grpc_conn.get_appointment(
+                TowerMessage::GetAppointment(msg) => {
+                    let res =
+                        self.handle.block_on(grpc_conn.get_appointment(
                             common_msgs::GetAppointmentRequest::from(msg.clone()),
                         ));
-                match res {
-                    Ok(r) => Ok(r.into_inner().into()),
-                    Err(e) if e.code() == Code::NotFound => Ok(AppointmentNotFound {
-                        locator: msg.locator,
+                    match res {
+                        Ok(r) => Ok(r.into_inner().into()),
+                        Err(e) if e.code() == Code::NotFound => Ok(AppointmentNotFound {
+                            locator: msg.locator,
+                        }
+                        .into()),
+                        Err(e) => warn_peer(
+                            e.message(),
+                            &format!(
+                                "GetAppointment request from {} failed because {}",
+                                peer,
+                                e.message()
+                            ),
+                        ),
                     }
-                    .into()),
-                    Err(e) => warn_peer(
-                        e.message(),
-                        &format!(
-                            "GetAppointment request from {} failed because {}",
-                            peer,
-                            e.message()
-                        ),
-                    ),
                 }
-            }
-            TowerMessage::GetSubscriptionInfo(msg) => {
-                let res = self.handle.block_on(
-                    grpc_conn
-                        .get_subscription_info(common_msgs::GetSubscriptionInfoRequest::from(msg)),
-                );
-                match res {
-                    Ok(r) => Ok(r.into_inner().into()),
-                    Err(e) => warn_peer(
-                        e.message(),
-                        &format!(
-                            "GetSubscriptionInfo request from {} failed because {}",
-                            peer,
-                            e.message()
+                TowerMessage::GetSubscriptionInfo(msg) => {
+                    let res =
+                        self.handle.block_on(grpc_conn.get_subscription_info(
+                            common_msgs::GetSubscriptionInfoRequest::from(msg),
+                        ));
+                    match res {
+                        Ok(r) => Ok(r.into_inner().into()),
+                        Err(e) => warn_peer(
+                            e.message(),
+                            &format!(
+                                "GetSubscriptionInfo request from {} failed because {}",
+                                peer,
+                                e.message()
+                            ),
                         ),
-                    ),
+                    }
                 }
+                // TODO: DeleteAppointment
+                // TowerMessageHandler as CustomMessageReader won't produce other than the above messages.
+                _ => unreachable!(),
             }
-            // TODO: DeleteAppointment
-            // TowerMessageHandler as CustomMessageReader won't produce other than the above messages.
-            _ => unreachable!(),
-        }
+        })
     }
 }
 
@@ -187,5 +209,72 @@ impl CustomMessageHandler for TowerMessageHandler {
 
     fn get_and_clear_pending_msg(&self) -> Vec<(PublicKey, TowerMessage)> {
         mem::take(&mut self.msg_queue.lock().unwrap())
+    }
+}
+
+/// A translation struct to translate LDK's logs to our logging system's logs.
+pub struct Logger;
+
+impl LightningLogger for Logger {
+    fn log(&self, record: &Record) {
+        match record.level {
+            Level::Error => log::error!(target: record.module_path, "{}", record.args),
+            Level::Warn => log::warn!(target: record.module_path, "{}", record.args),
+            Level::Info => log::info!(target: record.module_path, "{}", record.args),
+            Level::Debug => log::debug!(target: record.module_path, "{}", record.args),
+            Level::Trace => log::trace!(target: record.module_path, "{}", record.args),
+            _ => {}
+        }
+    }
+}
+
+pub async fn serve(
+    lightning_bind: SocketAddr,
+    grpc_bind: String,
+    shutdown_signal: Listener,
+    tower_sk: SecretKey,
+) {
+    let grpc_conn = loop {
+        match PublicTowerServicesClient::connect(grpc_bind.clone()).await {
+            Ok(conn) => break conn,
+            Err(_) => {
+                log::error!("Cannot connect to the gRPC server. Retrying shortly");
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            }
+        }
+    };
+    let tower_message_handler = Arc::new(TowerMessageHandler::new(
+        grpc_conn,
+        tokio::runtime::Handle::current(),
+    ));
+    let message_handler = MessageHandler {
+        chan_handler: Arc::new(ErroringMessageHandler::new()),
+        route_handler: Arc::new(IgnoringMessageHandler {}),
+    };
+    let ephemeral_bytes: [u8; 32] = get_random_bytes(32).try_into().unwrap();
+    let peer_manager = Arc::new(TowerPeerManager::new(
+        message_handler,
+        tower_sk,
+        &ephemeral_bytes,
+        Arc::new(Logger),
+        tower_message_handler,
+    ));
+    // To suppress an issue similar to https://github.com/rust-lang/rust-clippy/issues/2928
+    #[allow(clippy::expect_fun_call)]
+    let listener = tokio::net::TcpListener::bind(lightning_bind)
+        .await
+        .expect(&format!(
+            "Couldn't bind the lightning server to {}",
+            lightning_bind
+        ));
+    loop {
+        let tcp_stream = listener.accept().await.unwrap().0;
+        if shutdown_signal.is_triggered() {
+            return;
+        }
+        let peer_manager = peer_manager.clone();
+        tokio::spawn(async move {
+            lightning_net_tokio::setup_inbound(peer_manager, tcp_stream.into_std().unwrap()).await;
+        });
     }
 }

--- a/teos/src/api/mod.rs
+++ b/teos/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod http;
 pub mod internal;
+pub mod lightning;
 pub mod serde;
 pub mod tor;

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -46,13 +46,17 @@ impl std::error::Error for ConfigError {}
 #[structopt(rename_all = "lowercase")]
 #[structopt(version = env!("CARGO_PKG_VERSION"), about = "The Eye of Satoshi - Lightning watchtower")]
 pub struct Opt {
-    /// Address teos HTTP(s) API will bind to [default: localhost]
+    /// Address teos API will bind to [default: localhost]
     #[structopt(long)]
     pub api_bind: Option<String>,
 
+    /// Port teos Lightning API will bind to [default: 9815]
+    #[structopt(long)]
+    pub lightning_port: Option<u16>,
+
     /// Port teos HTTP(s) API will bind to [default: 9814]
     #[structopt(long)]
-    pub api_port: Option<u16>,
+    pub http_port: Option<u16>,
 
     /// Address teos RPC server will bind to [default: localhost]
     #[structopt(long)]
@@ -122,7 +126,8 @@ pub struct Opt {
 pub struct Config {
     // API
     pub api_bind: String,
-    pub api_port: u16,
+    pub lightning_port: u16,
+    pub http_port: u16,
 
     // RPC
     pub rpc_bind: String,
@@ -163,8 +168,11 @@ impl Config {
         if options.api_bind.is_some() {
             self.api_bind = options.api_bind.unwrap();
         }
-        if options.api_port.is_some() {
-            self.api_port = options.api_port.unwrap();
+        if options.lightning_port.is_some() {
+            self.lightning_port = options.lightning_port.unwrap();
+        }
+        if options.http_port.is_some() {
+            self.http_port = options.http_port.unwrap();
         }
         if options.rpc_bind.is_some() {
             self.rpc_bind = options.rpc_bind.unwrap();
@@ -254,7 +262,8 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             api_bind: "127.0.0.1".into(),
-            api_port: 9814,
+            http_port: 9814,
+            lightning_port: 9815,
             tor_support: false,
             tor_control_port: 9051,
             onion_hidden_service_port: 9814,
@@ -288,7 +297,8 @@ mod tests {
         fn default() -> Self {
             Self {
                 api_bind: None,
-                api_port: None,
+                http_port: None,
+                lightning_port: None,
                 tor_support: false,
                 tor_control_port: None,
                 onion_hidden_service_port: None,

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -809,6 +809,10 @@ mod tests {
             self.responder
                 .add_random_tracker(uuid, ConfirmationStatus::ConfirmedIn(100))
         }
+
+        pub(crate) fn get_signing_key(&self) -> SecretKey {
+            self.signing_key
+        }
     }
 
     async fn init_watcher(chain: &mut Blockchain) -> (Watcher, BitcoindStopper) {


### PR DESCRIPTION
This PR introduces [bolt13](https://github.com/sr-gi/bolt13/blob/master/13-watchtowers.md) message structs and their lightning (de)serialization, to be used by the tower (for the lightning server) and client apps.

LDK's (de)serialization traits are used to make the message structs sendable over wire (Readable and Writeable).

A small customized macro-based serialization framework [similar to LDK's](https://github.com/lightningdevkit/rust-lightning/blob/main/lightning/src/util/ser_macros.rs) was added to help organize the code and reduce its size.

Will push the [lightning server](https://github.com/meryacine/rust-teos/tree/lightning-server) to this PR later on.

Addresses #31 