### PR TITLE
Disable clippy::derive_partial_eq_without_eq in protos

### DIFF
--- a/teos-common/src/lib.rs
+++ b/teos-common/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Functionality shared between users and towers.
 
+// FIXME: This is a temporary fix. See https://github.com/tokio-rs/prost/issues/661
+#[allow(clippy::derive_partial_eq_without_eq)]
 pub mod protos {
     tonic::include_proto!("common.teos.v2");
 }

--- a/teos/src/lib.rs
+++ b/teos/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! A watchtower implementation written in Rust.
 
+// FIXME: This is a temporary fix. See https://github.com/tokio-rs/prost/issues/661
+#[allow(clippy::derive_partial_eq_without_eq)]
 pub mod protos {
     tonic::include_proto!("teos.v2");
 }


### PR DESCRIPTION
Clippy for Rust 1.63.0 raises a lint warning regarding structures implementing
PartialEq but not Eq: https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

The autogenerated code from the common protos does fall into this constrain. However, the current recommended
solution from the `prost` team is to disable the check: https://github.com/tokio-rs/prost/issues/661