### PR TITLE
Persists Tor secret key to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ btc_network = regtest
 
 ### Running `teosd` with tor
 
-This requires a tor daemon running on the same machine as `teosd` and a control port open on that daemon.
+This requires a Tor daemon running on the same machine as `teosd` and a control port open on that daemon.
 
-Download tor from the [torproject site](https://www.torproject.org/download/).
+Download Tor from the [torproject site](https://www.torproject.org/download/).
 
-To open tor's control port, you add the following to the tor config file ([source](https://2019.www.torproject.org/docs/faq.html.en#torrc)):
+To open tor's control port, you add the following to the Tor config file ([source](https://2019.www.torproject.org/docs/faq.html.en#torrc)):
 
 ```
 ## The port on which Tor will listen for local connections from Tor
@@ -85,7 +85,7 @@ CookieAuthentication 1
 CookieAuthFileGroupReadable 1
 ```
 
-Once the tor daemon is running, and the control port is open, make sure to enable the `tor_support` flag `teosd`.
+Once the Tor daemon is running, and the control port is open, make sure to enable the `tor_support` flag `teosd`.
 
 ### Tower id and signing key
 

--- a/teos/Cargo.toml
+++ b/teos/Cargo.toml
@@ -48,6 +48,7 @@ tonic-build = "0.6"
 
 [dev-dependencies]
 chunked_transfer = "1.4"
-rand = "0.8.4"
 jsonrpc-http-server = "17.1.0"
+rand = "0.8.4"
+tempdir = "0.3.7"
 tokio-stream = { version = "0.1.5", features = [ "net" ] }

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -97,11 +97,11 @@ pub struct Opt {
     #[structopt(long)]
     pub overwrite_key: bool,
 
-    /// If set, creates a tor endpoint to serve API data. This endpoint is additional to the clearnet HTTP API
+    /// If set, creates a Tor endpoint to serve API data. This endpoint is additional to the clearnet HTTP API
     #[structopt(long)]
     pub tor_support: bool,
 
-    /// tor control port [default: 9051]
+    /// Tor control port [default: 9051]
     #[structopt(long)]
     pub tor_control_port: Option<u16>,
 

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -291,8 +291,9 @@ async fn main() {
 
     // Add Tor Onion Service for public API
     let mut tor_task = Option::None;
+    let (tor_service_ready, ready_signal_tor) = triggered::trigger();
     if conf.tor_support {
-        log::info!("Starting up hidden tor service");
+        log::info!("Starting up Tor hidden service");
         let tor_control_port = conf.tor_control_port;
         let api_port = conf.api_port;
         let onion_port = conf.onion_hidden_service_port;
@@ -303,11 +304,14 @@ async fn main() {
                 api_port,
                 onion_port,
                 path_network,
+                tor_service_ready,
                 shutdown_signal_tor,
             )
             .await
             .unwrap();
         }));
+
+        ready_signal_tor.await
     }
 
     log::info!("Tower ready");

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -298,9 +298,15 @@ async fn main() {
         let onion_port = conf.onion_hidden_service_port;
 
         tor_task = Some(task::spawn(async move {
-            tor::expose_onion_service(tor_control_port, api_port, onion_port, shutdown_signal_tor)
-                .await
-                .unwrap();
+            tor::expose_onion_service(
+                tor_control_port,
+                api_port,
+                onion_port,
+                path_network,
+                shutdown_signal_tor,
+            )
+            .await
+            .unwrap();
         }));
     }
 


### PR DESCRIPTION
Persists the Tor secret to to `<teos_data_dir>/<network_dir>/onion_v3_sk` as suggested in #70.

Adds an additional trigger to the Tor task to signal when the service is ready. Otherwise the logs may show the tower being ready before the hidden service is reported:

```
[...]
2022-08-17T12:12:21.887Z INFO [teosd] Starting up hidden tor service
2022-08-17T12:12:21.887Z INFO [teosd] Tower ready
2022-08-17T12:12:21.888Z INFO [teos::api::tor] Loading Tor secret key from disk
2022-08-17T12:12:21.951Z INFO [teos::api::tor] onion service: 5ofdkbxqtfoerrqu2nh4h2zfkvpkvhompsrxgqxyowkdwegq2s5eqmyd.onion:2121
```

Close #70 