### PR TITLE
Adds Tor support to cln-plugin

### DIFF
--- a/watchtower-plugin/Cargo.toml
+++ b/watchtower-plugin/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 backoff = { version = "0.4.0", features = ["tokio"] }
 hex = { version = "0.4.3", features = [ "serde" ] }
 home = "0.5.3"
-reqwest = { version = "0.11", features = [ "blocking", "json" ] }
+reqwest = { version = "0.11", features = [ "blocking", "json", "socks" ] }
 log = "0.4.16"
 rusqlite = { version = "0.26.0", features = [ "bundled", "limits" ] }
 serde = "1.0.130"

--- a/watchtower-plugin/src/net/http.rs
+++ b/watchtower-plugin/src/net/http.rs
@@ -386,36 +386,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_send_appointment_unexpected() {
-        // An example to trigger an unexpected error would be to try to send data to a wrongly formatted url.
-        // This can not happen in the codebase, since the url is tested on registration, but it can be used to
-        // test that error path. Generally speaking, that error path should be unreachable.
-        let wrong_tower_net_addr = "server_addr";
-
-        let server = MockServer::start();
-        server.mock(|when, then| {
-            when.method(POST).path("/add_appointment");
-            then.status(200).header("content-type", "application/json");
-        });
-
-        let error = send_appointment(
-            get_random_user_id(),
-            wrong_tower_net_addr,
-            None,
-            &generate_random_appointment(None),
-            "user_sig",
-        )
-        .await
-        .unwrap_err();
-
-        if let AddAppointmentError::RequestError(e) = error {
-            assert!(matches!(e, RequestError::Unexpected { .. }))
-        } else {
-            panic!("Funny enough, Unexpected error was expected")
-        }
-    }
-
-    #[tokio::test]
     async fn test_post_request() {
         let server = MockServer::start();
         let api_mock = server.mock(|when, then| {
@@ -440,18 +410,6 @@ mod tests {
                 .await
                 .unwrap_err(),
             RequestError::ConnectionError { .. }
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_post_request_unexpected_error() {
-        let malformed_server_url = "server_addr";
-
-        assert!(matches!(
-            post_request(malformed_server_url, json!(""), None,)
-                .await
-                .unwrap_err(),
-            RequestError::Unexpected { .. }
         ));
     }
 

--- a/watchtower-plugin/src/wt_client.rs
+++ b/watchtower-plugin/src/wt_client.rs
@@ -28,6 +28,8 @@ pub struct WTClient {
     pub user_sk: SecretKey,
     /// The user identifier.
     pub user_id: UserId,
+    /// Optional proxy
+    pub proxy: Option<String>,
 }
 
 impl WTClient {
@@ -70,6 +72,7 @@ impl WTClient {
             dbm: Arc::new(Mutex::new(dbm)),
             user_sk,
             user_id,
+            proxy: None,
         }
     }
 


### PR DESCRIPTION
Check if the tower address is an onion address and proxies it through Tor if so. 

This assumes Tor is running on the backend, which is the same assumption used by CoreLN AFAICT https://lightning.readthedocs.io/TOR.html

Close #92 #93