### PR TITLE
Makes Tor task panics more user friendly

### DIFF
--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -299,7 +299,7 @@ async fn main() {
         let onion_port = conf.onion_hidden_service_port;
 
         tor_task = Some(task::spawn(async move {
-            tor::expose_onion_service(
+            if let Err(e) = tor::expose_onion_service(
                 tor_control_port,
                 api_port,
                 onion_port,
@@ -308,7 +308,10 @@ async fn main() {
                 shutdown_signal_tor,
             )
             .await
-            .unwrap();
+            {
+                eprintln!("Cannot connect to the Tor backend: {}", e);
+                std::process::exit(1);
+            }
         }));
 
         ready_signal_tor.await


### PR DESCRIPTION
Given we cannot address #57 atm, lets at least make it so if the Tor thread fails it does so in a more user friendly way.