### PR TITLE
Avoid having to hit the db if there is no data to delete

### DIFF
--- a/teos/src/gatekeeper.rs
+++ b/teos/src/gatekeeper.rs
@@ -325,11 +325,13 @@ impl chain::Listen for Gatekeeper {
 
         // Expired user deletion is delayed. Users are deleted when their subscription is outdated, not expired.
         let outdated_users = self.get_outdated_user_ids(height);
-        self.registered_users
-            .lock()
-            .unwrap()
-            .retain(|id, _| !outdated_users.contains(id));
-        self.dbm.lock().unwrap().batch_remove_users(&outdated_users);
+        if !outdated_users.is_empty() {
+            self.registered_users
+                .lock()
+                .unwrap()
+                .retain(|id, _| !outdated_users.contains(id));
+            self.dbm.lock().unwrap().batch_remove_users(&outdated_users);
+        }
 
         // Update last known block height
         self.last_known_block_height

--- a/teos/src/responder.rs
+++ b/teos/src/responder.rs
@@ -472,11 +472,13 @@ impl Responder {
         updated_users: &HashMap<UserId, UserInfo>,
         reason: DeletionReason,
     ) {
-        self.delete_trackers_from_memory(uuids, reason);
-        self.dbm
-            .lock()
-            .unwrap()
-            .batch_remove_appointments(uuids, updated_users);
+        if !uuids.is_empty() {
+            self.delete_trackers_from_memory(uuids, reason);
+            self.dbm
+                .lock()
+                .unwrap()
+                .batch_remove_appointments(uuids, updated_users);
+        }
     }
 }
 

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -678,11 +678,13 @@ impl Watcher {
         updated_users: &HashMap<UserId, UserInfo>,
         reason: DeletionReason,
     ) {
-        self.delete_appointments_from_memory(uuids, reason);
-        self.dbm
-            .lock()
-            .unwrap()
-            .batch_remove_appointments(uuids, updated_users);
+        if !uuids.is_empty() {
+            self.delete_appointments_from_memory(uuids, reason);
+            self.dbm
+                .lock()
+                .unwrap()
+                .batch_remove_appointments(uuids, updated_users);
+        }
     }
 
     /// Ges the number of users currently registered with the tower.


### PR DESCRIPTION
Currently, `DBM::batch_remove_{appointments, users}` was being hit even if there was no data to delete. This also applied to trying to delete data from memory, but the latter was less of an issue.

While this was not a thread by itself (no data was actually being deleted), it was certainly wasteful.