### PR TITLE
Adds a ready signal for the http API

### DIFF
--- a/teos/src/api/http.rs
+++ b/teos/src/api/http.rs
@@ -303,8 +303,8 @@ pub async fn serve(
             }
         }
     };
-    let (_, server) = warp::serve(router(grpc_conn))
-        .bind_with_graceful_shutdown(http_bind, async { shutdown_signal.await });
+    let (_, server) =
+        warp::serve(router(grpc_conn)).bind_with_graceful_shutdown(http_bind, shutdown_signal);
     service_ready.trigger();
     server.await
 }

--- a/teos/src/api/http.rs
+++ b/teos/src/api/http.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::net::SocketAddr;
 use tokio::time::Duration;
 use tonic::transport::Channel;
-use triggered::Listener;
+use triggered::{Listener, Trigger};
 use warp::{http::StatusCode, reject, reply, Filter, Rejection, Reply};
 
 use teos_common::appointment::LOCATOR_LEN;
@@ -288,7 +288,12 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Rejection> {
     }
 }
 
-pub async fn serve(http_bind: SocketAddr, grpc_bind: String, shutdown_signal: Listener) {
+pub async fn serve(
+    http_bind: SocketAddr,
+    grpc_bind: String,
+    service_ready: Trigger,
+    shutdown_signal: Listener,
+) {
     let grpc_conn = loop {
         match PublicTowerServicesClient::connect(grpc_bind.clone()).await {
             Ok(conn) => break conn,
@@ -300,6 +305,7 @@ pub async fn serve(http_bind: SocketAddr, grpc_bind: String, shutdown_signal: Li
     };
     let (_, server) = warp::serve(router(grpc_conn))
         .bind_with_graceful_shutdown(http_bind, async { shutdown_signal.await });
+    service_ready.trigger();
     server.await
 }
 

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -283,11 +283,14 @@ async fn main() {
             .unwrap();
     });
 
+    let (http_service_ready, ready_signal_http) = triggered::trigger();
     let http_api_task = task::spawn(http::serve(
         http_api_addr,
         internal_rpc_api_uri,
+        http_service_ready,
         shutdown_signal_http,
     ));
+    ready_signal_http.await;
 
     // Add Tor Onion Service for public API
     let mut tor_task = Option::None;


### PR DESCRIPTION
In normal conditions, if the http API cannot bootstrap (due to the gRPC server being temporarily unavailable) it will just retry until it connects.

However, this is done asynchronously, meaning that it could be the case that the tower is reported as ready when it is actually not. This can be hit during E2E testing if the tower is restarted too quickly, resulting in a test failure:

https://github.com/sr-gi/rust-teos/runs/8074272734?check_suite_focus=true#step:9:5543
https://github.com/sr-gi/rust-teos/runs/8074272734?check_suite_focus=true#step:9:6970