### PR TITLE
watchtower-plugin: get rid of unnecessary `Arc<Mutex<` in `WTClient`

### DIFF
--- a/watchtower-plugin/src/retrier.rs
+++ b/watchtower-plugin/src/retrier.rs
@@ -259,8 +259,6 @@ impl Retrier {
                     .lock()
                     .unwrap()
                     .dbm
-                    .lock()
-                    .unwrap()
                     .load_appointment(locator)
                     .unwrap();
 


### PR DESCRIPTION
DBM doesn't need to wrapped in an `Arc<Mutex<` since `WTClient` is already wrapped in an `Arc<Mutex<` in all occurrences and DBM is neither `Copy` nor `Clone`.
