### PR TITLE
Fixes #119

### DIFF
--- a/teos/src/api/internal.rs
+++ b/teos/src/api/internal.rs
@@ -394,7 +394,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_all_appointments() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         let response = internal_api
             .get_all_appointments(Request::new(()))
@@ -402,12 +402,12 @@ mod tests_private_api {
             .unwrap()
             .into_inner();
 
-        assert!(matches!(response, msgs::GetAllAppointmentsResponse { .. }))
+        assert!(matches!(response, msgs::GetAllAppointmentsResponse { .. }));
     }
 
     #[tokio::test]
     async fn test_get_all_appointments_watcher() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // Add data to the Watcher so we can retrieve it later on
         let (user_sk, user_pk) = get_random_keypair();
@@ -435,7 +435,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_all_appointments_responder() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // Add data to the Responser so we can retrieve it later on
         internal_api
@@ -457,7 +457,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_appointments() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         let locator = Locator::new(get_random_tx().txid()).to_vec();
         let response = internal_api
@@ -471,7 +471,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_appointments_watcher() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         for i in 0..3 {
             // Create a dispute tx to be used for creating different dummy appointments with the same locator.
@@ -521,7 +521,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_appointments_responder() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         for i in 0..3 {
             // Create a dispute tx to be used for creating different trackers.
@@ -572,7 +572,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_tower_info_empty() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         let response = internal_api
             .get_tower_info(Request::new(()))
@@ -588,7 +588,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_tower_info() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // Register a user
         let (user_sk, user_pk) = get_random_keypair();
@@ -627,7 +627,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_users() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
         let mut users = HashSet::new();
 
         // Add a couple of users
@@ -649,7 +649,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_users_empty() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         let response = internal_api
             .get_users(Request::new(()))
@@ -662,7 +662,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_user() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // Register a user and get it back
         let (user_sk, user_pk) = get_random_keypair();
@@ -705,7 +705,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_user_not_found() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // Non-registered user
         let (_, user_pk) = get_random_keypair();
@@ -726,7 +726,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_stop() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         assert!(!internal_api.shutdown_trigger.is_triggered());
         internal_api.stop(Request::new(())).await.unwrap();
@@ -746,7 +746,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_register() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         let (_, user_pk) = get_random_keypair();
 
@@ -766,7 +766,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_register_wrong_user_id() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         let mut user_ids = Vec::new();
 
@@ -797,7 +797,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_register_max_slots() {
-        let internal_api = create_api_with_config(ApiConfig::new(u32::MAX, DURATION)).await;
+        let (internal_api, _s) = create_api_with_config(ApiConfig::new(u32::MAX, DURATION)).await;
 
         let (_, user_pk) = get_random_keypair();
         let user_id = UserId(user_pk).to_vec();
@@ -825,7 +825,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_register_service_unavailable() {
-        let internal_api =
+        let (internal_api, _s) =
             create_api_with_config(ApiConfig::new(u32::MAX, DURATION).bitcoind_unreachable()).await;
 
         let (_, user_pk) = get_random_keypair();
@@ -845,7 +845,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // User must be registered
         let (user_sk, user_pk) = get_random_keypair();
@@ -871,7 +871,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment_non_registered() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // User is not registered this time
         let (user_sk, _) = get_random_keypair();
@@ -899,7 +899,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment_not_enough_slots() {
-        let internal_api = create_api_with_config(ApiConfig::new(0, DURATION)).await;
+        let (internal_api, _s) = create_api_with_config(ApiConfig::new(0, DURATION)).await;
 
         // User is registered but has no slots
         let (user_sk, user_pk) = get_random_keypair();
@@ -928,7 +928,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment_subscription_expired() {
-        let internal_api = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
+        let (internal_api, _s) = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
 
         // User is registered but subscription is expired
         let (user_sk, user_pk) = get_random_keypair();
@@ -954,7 +954,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment_already_triggered() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         let (user_sk, user_pk) = get_random_keypair();
         let user_id = UserId(user_pk);
@@ -985,7 +985,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment_service_unavailable() {
-        let internal_api =
+        let (internal_api, _s) =
             create_api_with_config(ApiConfig::new(u32::MAX, DURATION).bitcoind_unreachable()).await;
 
         let (user_sk, _) = get_random_keypair();
@@ -1009,7 +1009,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_appointment() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // The user must be registered
         let (user_sk, user_pk) = get_random_keypair();
@@ -1037,12 +1037,12 @@ mod tests_public_api {
         assert!(matches!(
             response,
             common_msgs::GetAppointmentResponse { .. }
-        ))
+        ));
     }
 
     #[tokio::test]
     async fn test_get_appointment_non_registered() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // Add a first user to link the appointment to him
         let (user_sk, user_pk) = get_random_keypair();
@@ -1070,7 +1070,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_appointment_non_existent() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // The user is registered but the appointment does not exist
         let (user_sk, user_pk) = get_random_keypair();
@@ -1097,7 +1097,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_appointment_subscription_expired() {
-        let internal_api = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
+        let (internal_api, _s) = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
 
         // Register the user
         let (user_sk, user_pk) = get_random_keypair();
@@ -1125,7 +1125,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_appointment_service_unavailable() {
-        let internal_api =
+        let (internal_api, _s) =
             create_api_with_config(ApiConfig::new(SLOTS, DURATION).bitcoind_unreachable()).await;
 
         let (user_sk, _) = get_random_keypair();
@@ -1148,7 +1148,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_subscription_info() {
-        let internal_api = create_api().await;
+        let (internal_api, _s) = create_api().await;
 
         // The user must be registered
         let (user_sk, user_pk) = get_random_keypair();
@@ -1167,12 +1167,12 @@ mod tests_public_api {
         assert!(matches!(
             response,
             common_msgs::GetSubscriptionInfoResponse { .. }
-        ))
+        ));
     }
 
     #[tokio::test]
     async fn test_get_subscription_info_non_registered() {
-        let internal_api = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
+        let (internal_api, _s) = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
 
         // The user is not registered
         let (user_sk, _) = get_random_keypair();
@@ -1195,7 +1195,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_subscription_info_expired() {
-        let internal_api = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
+        let (internal_api, _s) = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
 
         // The user is registered but the subscription has expired
         let (user_sk, user_pk) = get_random_keypair();
@@ -1219,7 +1219,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_subscription_info_service_unavailable() {
-        let internal_api =
+        let (internal_api, _s) =
             create_api_with_config(ApiConfig::new(SLOTS, DURATION).bitcoind_unreachable()).await;
 
         let (user_sk, _) = get_random_keypair();

--- a/teos/src/carrier.rs
+++ b/teos/src/carrier.rs
@@ -245,7 +245,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
 
@@ -269,7 +269,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
@@ -289,7 +289,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
@@ -311,7 +311,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
@@ -336,8 +336,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
-
+        start_server(bitcoind_mock.server);
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
@@ -355,7 +354,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
@@ -407,7 +406,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         let tx = consensus::deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
@@ -425,7 +424,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         let tx = consensus::deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
@@ -440,7 +439,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         assert_eq!(
@@ -455,7 +454,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
         assert_eq!(carrier.get_block_height(&BlockHash::default()), None);
@@ -468,7 +467,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let tx = consensus::deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);
@@ -481,7 +480,7 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        start_server(bitcoind_mock);
+        start_server(bitcoind_mock.server);
 
         let tx = consensus::deserialize::<Transaction>(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height);


### PR DESCRIPTION
In many of the tests, a `BitcoindMock` was being created and, alongside it, a `jsonrpc-http` server started to receive `jsonrpc` request from the tower. However, these servers were never stopped after every individual test (only by the end of the test suite) resulting in a high number of opened file descriptors.

Turns out `jsonrpc-http-server::Server` has a `CloseHandle` that allows us to close the server from a different thread.


h/t to @erikarvstedt for pointing out the root of the issue.