### PR TITLE
Removes chunked-transfer from deps

### DIFF
--- a/teos/Cargo.toml
+++ b/teos/Cargo.toml
@@ -47,7 +47,6 @@ teos-common = { path = "../teos-common" }
 tonic-build = "0.6"
 
 [dev-dependencies]
-chunked_transfer = "1.4"
 jsonrpc-http-server = "17.1.0"
 rand = "0.8.4"
 tempdir = "0.3.7"


### PR DESCRIPTION
chunked-transfer was used in an old version of the test suite for a custom HTTP server. The test server was removed in bbd3857c70e321f1a563036c11deb184d439fb3e, hence the dependency was never used from that point on.