### PR TITLE
Implements an internal txindex so we don't have to run bitcoind with `txindex=1`

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -19,7 +19,6 @@ You can get Bitcoin Core from [bitcoincore.org](https://bitcoincore.org/en/downl
 
 Bitcoin needs to be running with the following options enabled:
 
-- `txindex` to be able to look for non-wallet transactions
 - `server` to run rpc commands
 
 Here's an example of a `bitcoin.conf` you can use for mainnet. **DO NOT USE THE PROVIDED RPC USER AND PASSWORD.**
@@ -30,9 +29,6 @@ server=1
 rpcuser=user
 rpcpassword=passwd
 rpcservertimeout=600
-
-# [blockchain]
-txindex=1
 
 # [others]
 daemon=1

--- a/teos/src/lib.rs
+++ b/teos/src/lib.rs
@@ -22,6 +22,7 @@ pub mod responder;
 #[doc(hidden)]
 mod rpc_errors;
 pub mod tls;
+mod tx_index;
 pub mod watcher;
 
 #[cfg(test)]

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -213,7 +213,7 @@ async fn main() {
     let watcher = Arc::new(Watcher::new(
         gatekeeper.clone(),
         responder.clone(),
-        last_n_blocks,
+        &last_n_blocks,
         tip.height,
         tower_sk,
         TowerId(tower_pk),

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -8,7 +8,6 @@
 */
 
 use rand::Rng;
-use std::ops::Deref;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 
@@ -36,6 +35,7 @@ use lightning_block_sync::{
     AsyncBlockSourceResult, BlockHeaderData, BlockSource, BlockSourceError, UnboundedCache,
 };
 
+use teos_common::constants::IRREVOCABLY_RESOLVED;
 use teos_common::cryptography::{get_random_bytes, get_random_keypair};
 use teos_common::test_utils::{generate_random_appointment, get_random_user_id, TXID_HEX, TX_HEX};
 use teos_common::UserId;
@@ -46,6 +46,7 @@ use crate::dbm::DBM;
 use crate::extended_appointment::{ExtendedAppointment, UUID};
 use crate::gatekeeper::{Gatekeeper, UserInfo};
 use crate::responder::{ConfirmationStatus, Responder, TransactionTracker};
+use crate::rpc_errors;
 use crate::watcher::{Breach, Watcher};
 
 pub(crate) const SLOTS: u32 = 21;
@@ -353,18 +354,15 @@ pub(crate) fn store_appointment_and_fks_to_db(
 }
 
 pub(crate) async fn get_last_n_blocks(chain: &mut Blockchain, n: usize) -> Vec<ValidatedBlock> {
-    let tip = chain.tip();
-    let poller = ChainPoller::new(chain, Network::Bitcoin);
+    let mut last_n_blocks = Vec::with_capacity(n);
+    let mut last_known_block = Ok(chain.tip());
+    let poller = ChainPoller::new(chain, Network::Regtest);
 
-    let mut last_n_blocks = Vec::new();
-    let mut last_known_block = tip;
     for _ in 0..n {
-        let block = poller.fetch_block(&last_known_block).await.unwrap();
-        last_known_block = poller
-            .look_up_previous_header(&last_known_block)
-            .await
-            .unwrap();
+        let header = last_known_block.unwrap();
+        let block = poller.fetch_block(&header).await.unwrap();
         last_n_blocks.push(block);
+        last_known_block = poller.look_up_previous_header(&header).await;
     }
 
     last_n_blocks
@@ -372,12 +370,14 @@ pub(crate) async fn get_last_n_blocks(chain: &mut Blockchain, n: usize) -> Vec<V
 
 pub(crate) enum MockedServerQuery {
     Regular,
+    InMempoool,
     Error(i64),
 }
 
 pub(crate) fn create_carrier(query: MockedServerQuery, height: u32) -> (Carrier, BitcoindStopper) {
     let bitcoind_mock = match query {
-        MockedServerQuery::Regular => BitcoindMock::new(MockOptions::empty()),
+        MockedServerQuery::Regular => BitcoindMock::new(MockOptions::default()),
+        MockedServerQuery::InMempoool => BitcoindMock::new(MockOptions::in_mempool()),
         MockedServerQuery::Error(x) => BitcoindMock::new(MockOptions::with_error(x)),
     };
     let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
@@ -390,17 +390,23 @@ pub(crate) fn create_carrier(query: MockedServerQuery, height: u32) -> (Carrier,
     )
 }
 
-pub(crate) fn create_responder(
-    tip: ValidatedBlockHeader,
+pub(crate) async fn create_responder(
+    chain: &mut Blockchain,
     gatekeeper: Arc<Gatekeeper>,
     dbm: Arc<Mutex<DBM>>,
     server_url: &str,
 ) -> Responder {
+    let height = chain.tip().height;
+    // For the local TxIndex logic to be sound, our index needs to have, at least, IRREVOCABLY_RESOLVED blocks
+    debug_assert!(height >= IRREVOCABLY_RESOLVED);
+
+    let last_n_blocks = get_last_n_blocks(chain, IRREVOCABLY_RESOLVED as usize).await;
+
     let bitcoin_cli = Arc::new(BitcoindClient::new(server_url, Auth::None).unwrap());
     let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
-    let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, tip.deref().height);
+    let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, height);
 
-    Responder::new(carrier, gatekeeper, dbm)
+    Responder::new(&last_n_blocks, height, carrier, gatekeeper, dbm)
 }
 
 pub(crate) async fn create_watcher(
@@ -463,7 +469,7 @@ impl Default for ApiConfig {
 pub(crate) async fn create_api_with_config(
     api_config: ApiConfig,
 ) -> (Arc<InternalAPI>, BitcoindStopper) {
-    let bitcoind_mock = BitcoindMock::new(MockOptions::empty());
+    let bitcoind_mock = BitcoindMock::new(MockOptions::default());
     let mut chain = Blockchain::default().with_height(START_HEIGHT);
 
     let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
@@ -474,7 +480,8 @@ pub(crate) async fn create_api_with_config(
         EXPIRY_DELTA,
         dbm.clone(),
     ));
-    let responder = create_responder(chain.tip(), gk.clone(), dbm.clone(), bitcoind_mock.url());
+    let responder =
+        create_responder(&mut chain, gk.clone(), dbm.clone(), bitcoind_mock.url()).await;
     let (watcher, stopper) = create_watcher(
         &mut chain,
         Arc::new(responder),
@@ -527,43 +534,24 @@ pub(crate) struct BitcoindMock {
     stopper: BitcoindStopper,
 }
 
+#[derive(Default)]
 pub(crate) struct MockOptions {
     error_code: Option<i64>,
-    block_hash: Option<BlockHash>,
-    height: Option<usize>,
+    in_mempool: bool,
 }
 
 impl MockOptions {
-    pub fn new(error_code: i64, block_hash: BlockHash, height: usize) -> Self {
-        Self {
-            error_code: Some(error_code),
-            block_hash: Some(block_hash),
-            height: Some(height),
-        }
-    }
-
-    pub fn empty() -> Self {
-        Self {
-            error_code: None,
-            block_hash: None,
-            height: None,
-        }
-    }
-
     pub fn with_error(error_code: i64) -> Self {
         Self {
             error_code: Some(error_code),
-            block_hash: None,
-            height: None,
+            in_mempool: false,
         }
     }
 
-    #[allow(dead_code)]
-    pub fn with_block(block_hash: BlockHash, height: usize) -> Self {
+    pub fn in_mempool() -> Self {
         Self {
             error_code: None,
-            block_hash: Some(block_hash),
-            height: Some(height),
+            in_mempool: true,
         }
     }
 }
@@ -577,15 +565,10 @@ impl BitcoindMock {
                 Err(JsonRpcError::new(JsonRpcErrorCode::ServerError(error)))
             });
             io.add_alias("sendrawtransaction", "error");
+            io.add_alias("getrawtransaction", "error");
         } else {
             BitcoindMock::add_sendrawtransaction(&mut io);
-        }
-
-        if let Some(block_hash) = options.block_hash {
-            BitcoindMock::add_getrawtransaction(&mut io, block_hash.to_string());
-            if let Some(height) = options.height {
-                BitcoindMock::add_getblockheader(&mut io, block_hash.to_string(), height);
-            }
+            BitcoindMock::add_getrawtransaction(&mut io, options.in_mempool);
         }
 
         let server = ServerBuilder::new(io)
@@ -606,41 +589,25 @@ impl BitcoindMock {
         });
     }
 
-    fn add_getrawtransaction(io: &mut IoHandler, block_hash: String) {
+    fn add_getrawtransaction(io: &mut IoHandler, in_mempool: bool) {
         io.add_sync_method("getrawtransaction", move |_params: Params|  {
-            match _params {
-                Params::Array(x) => match x[1] {
-                    Value::Bool(x) => {
-                        if x {
-                            Ok(serde_json::json!({"hex": TX_HEX, "txid": TXID_HEX, "hash": TXID_HEX, "size": 0, 
-                            "vsize": 0, "version": 1, "locktime": 0, "vin": [], "vout": [], "blockhash": block_hash }))
-                        } else {
-                            Ok(Value::String(TX_HEX.to_owned()))
+            if !in_mempool {
+                Err(JsonRpcError::new(JsonRpcErrorCode::ServerError(rpc_errors::RPC_INVALID_ADDRESS_OR_KEY as i64)))
+            } else {
+                match _params {
+                    Params::Array(x) => match x[1] {
+                        Value::Bool(x) => {
+                            if x {
+                                Ok(serde_json::json!({"hex": TX_HEX, "txid": TXID_HEX, "hash": TXID_HEX, "size": 0, 
+                                "vsize": 0, "version": 1, "locktime": 0, "vin": [], "vout": [] }))
+                            } else {
+                                Ok(Value::String(TX_HEX.to_owned()))
+                            }
                         }
-                    }
-                    _ => panic!("Boolean param not found"),
-                },
-                _ => panic!("No params found"),
-            }
-        })
-    }
-
-    fn add_getblockheader(io: &mut IoHandler, block_hash: String, height: usize) {
-        io.add_sync_method("getblockheader", move |_params: Params|  {
-            match _params {
-                Params::Array(x) => match x[1] {
-                    Value::Bool(x) => {
-                        if x {
-                            Ok(serde_json::json!({"hash": block_hash, "confirmations": 1, "height": height, "version": 1, 
-                            "merkleroot": "4eca41cf0fa551346842eb317564a403e39553444790a65f949f95bc18d24643", "time": 1645719068, "nonce": 2, "bits": "207fffff", 
-                            "difficulty": 0.0, "chainwork": "0000000000000000000000000000000000000000000000000000000000001146", "nTx": 1}))
-                        } else {
-                            Ok(Value::String(TX_HEX.to_owned()))
-                        }
-                    }
-                    _ => panic!("Boolean param not found"),
-                },
-                _ => panic!("No params found"),
+                        _ => panic!("Boolean param not found"),
+                    },
+                    _ => panic!("No params found"),
+                }
             }
         })
     }

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -419,7 +419,7 @@ pub(crate) async fn create_watcher(
         Watcher::new(
             gatekeeper,
             responder,
-            last_n_blocks,
+            &last_n_blocks,
             chain.get_block_count(),
             tower_sk,
             tower_id,

--- a/teos/src/tx_index.rs
+++ b/teos/src/tx_index.rs
@@ -1,0 +1,401 @@
+use std::collections::{HashMap, VecDeque};
+use std::fmt;
+use std::hash::Hash;
+
+use bitcoin::hash_types::BlockHash;
+use bitcoin::{BlockHeader, Transaction, Txid};
+use lightning_block_sync::poll::ValidatedBlock;
+
+use teos_common::appointment::Locator;
+
+/// A trait implemented by types that can be used as key in a [TxIndex].
+pub trait Key: Hash {
+    fn from_txid(txid: Txid) -> Self;
+}
+
+impl Key for Txid {
+    fn from_txid(txid: Txid) -> Self {
+        txid
+    }
+}
+
+impl Key for Locator {
+    fn from_txid(txid: Txid) -> Self {
+        Locator::new(txid)
+    }
+}
+
+pub enum Type {
+    Transaction,
+    BlockHash,
+}
+
+pub enum Data {
+    Transaction(Transaction),
+    BlockHash(BlockHash),
+}
+
+impl fmt::Display for Data {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Data::Transaction(_) => write!(f, "Transaction"),
+            Data::BlockHash(_) => write!(f, "BlockHash"),
+        }
+    }
+}
+
+/// A trait implemented by types that can be used as value in a [TxIndex].
+pub trait Value {
+    fn get_type() -> Type;
+    fn from_data(d: Data) -> Self;
+}
+
+impl Value for BlockHash {
+    fn get_type() -> Type {
+        Type::BlockHash
+    }
+
+    fn from_data(d: Data) -> Self {
+        match d {
+            Data::BlockHash(b) => b,
+            other => panic!("Cannot build a BlockHash from {}", other),
+        }
+    }
+}
+
+impl Value for Transaction {
+    fn get_type() -> Type {
+        Type::Transaction
+    }
+
+    fn from_data(d: Data) -> Self {
+        match d {
+            Data::Transaction(t) => t,
+            other => panic!("Cannot build a BlockHash from {}", other),
+        }
+    }
+}
+
+/// Data structure used to index locators computed from parsed blocks.
+///
+/// Holds up to `size` blocks with their corresponding computed [Locator]s.
+#[derive(Debug)]
+pub struct TxIndex<K, V> {
+    /// A [K]:[V] map.
+    index: HashMap<K, V>,
+    /// Vector of block hashes covered by the index.
+    blocks: VecDeque<BlockHash>,
+    /// Map of [BlockHash]:[Vec<K>]. Used to remove data from the index.
+    tx_in_block: HashMap<BlockHash, Vec<K>>,
+    /// The height of the last block included in the index.
+    tip: u32,
+    /// Maximum size of the index.
+    size: usize,
+}
+
+impl<K, V> TxIndex<K, V>
+where
+    K: Key + std::cmp::Eq + Copy,
+    V: Value + Clone,
+    Self: Sized,
+{
+    pub fn new(last_n_blocks: &[ValidatedBlock], height: u32) -> Self {
+        let size = last_n_blocks.len();
+        let mut tx_index = Self {
+            index: HashMap::new(),
+            blocks: VecDeque::with_capacity(size),
+            tx_in_block: HashMap::new(),
+            tip: height,
+            size,
+        };
+
+        for block in last_n_blocks.iter().rev() {
+            if let Some(prev_block_hash) = tx_index.blocks.back() {
+                if block.header.prev_blockhash != *prev_block_hash {
+                    panic!("last_n_blocks contains unchained blocks");
+                }
+            };
+
+            let map = block
+                .txdata
+                .iter()
+                .map(|tx| {
+                    (
+                        K::from_txid(tx.txid()),
+                        match V::get_type() {
+                            Type::Transaction => V::from_data(Data::Transaction(tx.clone())),
+                            Type::BlockHash => {
+                                V::from_data(Data::BlockHash(block.header.block_hash()))
+                            }
+                        },
+                    )
+                })
+                .collect();
+
+            tx_index.update(block.header, &map);
+        }
+
+        tx_index
+    }
+
+    /// Gets an item from the index if present. [None] otherwise.
+    pub fn get<'a>(&'a self, k: &'a K) -> Option<&V> {
+        self.index.get(k)
+    }
+
+    /// Checks whether the index contains a certain key.
+    pub fn contains_key(&self, k: &K) -> bool {
+        self.index.contains_key(k)
+    }
+
+    /// Checks if the index if full.
+    pub fn is_full(&self) -> bool {
+        self.blocks.len() > self.size
+    }
+
+    /// Get's the height of a given block based on its position in the block queue.
+    pub fn get_height(&self, block_hash: &BlockHash) -> Option<usize> {
+        let pos = self.blocks.iter().position(|x| x == block_hash)?;
+        Some(self.tip as usize + pos + 1 - self.blocks.len())
+    }
+
+    /// Updates the index by adding data from a new block. Removes the oldest block if the index is full afterwards.
+    pub fn update(&mut self, block_header: BlockHeader, data: &HashMap<K, V>) {
+        self.blocks.push_back(block_header.block_hash());
+
+        let ks = data
+            .iter()
+            .map(|(k, v)| {
+                self.index.insert(*k, v.clone());
+                *k
+            })
+            .collect();
+
+        self.tx_in_block.insert(block_header.block_hash(), ks);
+
+        if self.is_full() {
+            // Avoid logging during bootstrap
+            log::info!("New block added to index: {}", block_header.block_hash());
+            self.tip += 1;
+            self.remove_oldest_block();
+        }
+    }
+
+    /// Fixes the index by removing disconnected data.
+    pub fn remove_disconnected_block(&mut self, block_hash: &BlockHash) {
+        if let Some(ks) = self.tx_in_block.remove(block_hash) {
+            self.index.retain(|k, _| !ks.contains(k));
+
+            // Blocks should be disconnected from last backwards. Log if that's not the case so we can revisit this and fix it.
+            if let Some(ref h) = self.blocks.pop_back() {
+                if h != block_hash {
+                    log::error!("Disconnected block does not match the oldest block stored in the TxIndex ({} != {})", block_hash, h);
+                }
+            }
+        } else {
+            log::warn!("The index is already empty");
+        }
+    }
+
+    /// Removes the oldest block from the index.
+    /// This removes data from `self.blocks`, `self.tx_in_block` and `self.index`.
+    pub fn remove_oldest_block(&mut self) {
+        let h = self.blocks.pop_front().unwrap();
+        let ks = self.tx_in_block.remove(&h).unwrap();
+        self.index.retain(|k, _| !ks.contains(k));
+
+        log::info!("Oldest block removed from index: {}", h);
+    }
+}
+
+impl<K: std::fmt::Debug, V: std::fmt::Debug> fmt::Display for TxIndex<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "index: {:?}\n\nblocks: {:?}\n\ntx_in_block: {:?}\n\nsize: {}",
+            self.index, self.blocks, self.tx_in_block, self.size
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ops::Deref;
+
+    use crate::test_utils::{get_last_n_blocks, Blockchain};
+
+    use bitcoin::Block;
+
+    impl<K, V> TxIndex<K, V>
+    where
+        K: Key + std::cmp::Eq + Copy,
+        V: Value + Clone,
+        Self: Sized,
+    {
+        pub fn index_mut(&mut self) -> &mut HashMap<K, V> {
+            &mut self.index
+        }
+
+        pub fn blocks(&self) -> &VecDeque<BlockHash> {
+            &self.blocks
+        }
+    }
+
+    #[tokio::test]
+    async fn test_new() {
+        let height = 10;
+        let mut chain = Blockchain::default().with_height(height as usize);
+        let last_six_blocks = get_last_n_blocks(&mut chain, 6).await;
+        let blocks: Vec<Block> = last_six_blocks
+            .iter()
+            .map(|block| block.deref().clone())
+            .collect();
+
+        let cache: TxIndex<Locator, Transaction> = TxIndex::new(&last_six_blocks, height);
+        assert_eq!(blocks.len(), cache.size);
+        for block in blocks.iter() {
+            assert!(cache.blocks().contains(&block.block_hash()));
+
+            let mut locators = Vec::new();
+            for tx in block.txdata.iter() {
+                let locator = Locator::new(tx.txid());
+                assert!(cache.contains_key(&locator));
+                locators.push(locator);
+            }
+
+            assert_eq!(cache.tx_in_block[&block.block_hash()], locators);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_height() {
+        let cache_size = 10;
+        let height = 50;
+        let mut chain = Blockchain::default().with_height_and_txs(height, 42);
+        let last_n_blocks = get_last_n_blocks(&mut chain, cache_size).await;
+
+        // last_n_blocks is ordered from latest to earliest
+        let first_block = last_n_blocks.get(cache_size - 1).unwrap();
+        let last_block = last_n_blocks.get(0).unwrap();
+        let mid = last_n_blocks.get(cache_size / 2).unwrap();
+
+        let cache: TxIndex<Locator, Transaction> = TxIndex::new(&last_n_blocks, height as u32);
+
+        assert_eq!(
+            cache.get_height(&first_block.block_hash()).unwrap(),
+            height - cache_size + 1
+        );
+        assert_eq!(cache.get_height(&last_block.block_hash()).unwrap(), height);
+        assert_eq!(
+            cache.get_height(&mid.block_hash()).unwrap(),
+            height - cache_size / 2
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_height_not_found() {
+        let cache_size = 10;
+        let height = 50;
+        let mut chain = Blockchain::default().with_height_and_txs(height, 42);
+        let cache: TxIndex<Locator, Transaction> = TxIndex::new(
+            &get_last_n_blocks(&mut chain, cache_size).await,
+            height as u32,
+        );
+
+        let fake_hash = BlockHash::default();
+        assert!(matches!(cache.get_height(&fake_hash), None));
+    }
+
+    #[tokio::test]
+    async fn test_update() {
+        let height = 10;
+        let mut chain = Blockchain::default().with_height(height as usize);
+        let mut last_n_blocks = get_last_n_blocks(&mut chain, 7).await;
+
+        // Store the last block to use it for an update and the first to check eviction
+        // Notice that the list of blocks is ordered from last to first.
+        let last_block = last_n_blocks.remove(0);
+        let first_block = last_n_blocks.last().unwrap().deref().clone();
+
+        // Init the cache with the 6 block before the last
+        let mut cache = TxIndex::new(&last_n_blocks, height);
+
+        // Update the cache with the last block
+        let locator_tx_map = last_block
+            .txdata
+            .iter()
+            .map(|tx| (Locator::new(tx.txid()), tx.clone()))
+            .collect();
+
+        cache.update(last_block.deref().header, &locator_tx_map);
+
+        // Check that the new data is in the cache
+        assert!(cache.blocks().contains(&last_block.block_hash()));
+        for (locator, _) in locator_tx_map.iter() {
+            assert!(cache.contains_key(locator));
+        }
+        assert_eq!(
+            cache.tx_in_block[&last_block.block_hash()],
+            locator_tx_map.keys().cloned().collect::<Vec<Locator>>()
+        );
+
+        // Check that the data from the first block has been evicted
+        assert!(!cache.blocks().contains(&first_block.block_hash()));
+        for tx in first_block.txdata.iter() {
+            assert!(!cache.contains_key(&Locator::new(tx.txid())));
+        }
+        assert!(!cache.tx_in_block.contains_key(&first_block.block_hash()));
+    }
+
+    #[tokio::test]
+    async fn test_remove_disconnected_block() {
+        let cache_size = 6;
+        let height = cache_size * 2;
+        let mut chain = Blockchain::default().with_height_and_txs(height, 42);
+        let mut cache: TxIndex<Locator, Transaction> = TxIndex::new(
+            &get_last_n_blocks(&mut chain, cache_size).await,
+            height as u32,
+        );
+
+        // TxIndex::fix removes the last connected block and removes all the associated data
+        for i in 0..cache_size {
+            let header = chain
+                .at_height(chain.get_block_count() as usize - i)
+                .deref()
+                .header;
+            let locators = cache.tx_in_block.get(&header.block_hash()).unwrap().clone();
+
+            // Make sure there's data regarding the target block in the cache before fixing it
+            assert_eq!(cache.blocks().len(), cache.size - i);
+            assert!(cache.blocks().contains(&header.block_hash()));
+            assert!(!locators.is_empty());
+            for locator in locators.iter() {
+                assert!(cache.contains_key(locator));
+            }
+
+            cache.remove_disconnected_block(&header.block_hash());
+
+            // Check that the block data is not in the cache anymore
+            assert_eq!(cache.blocks().len(), cache.size - i - 1);
+            assert!(!cache.blocks().contains(&header.block_hash()));
+            assert!(cache.tx_in_block.get(&header.block_hash()).is_none());
+            for locator in locators.iter() {
+                assert!(!cache.contains_key(locator));
+            }
+        }
+
+        // At this point the cache should be empty, fixing it further shouldn't do anything
+        for i in cache_size..cache_size * 2 {
+            assert!(cache.index.is_empty());
+            assert!(cache.blocks().is_empty());
+            assert!(cache.tx_in_block.is_empty());
+
+            let header = chain
+                .at_height(chain.get_block_count() as usize - i)
+                .deref()
+                .header;
+            cache.remove_disconnected_block(&header.block_hash());
+        }
+    }
+}

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -4,12 +4,10 @@ use log;
 
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::fmt;
 use std::iter::FromIterator;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
-use bitcoin::hash_types::BlockHash;
 use bitcoin::secp256k1::SecretKey;
 use bitcoin::{BlockHeader, Transaction};
 use lightning::chain;
@@ -24,133 +22,7 @@ use crate::dbm::DBM;
 use crate::extended_appointment::{AppointmentSummary, ExtendedAppointment, UUID};
 use crate::gatekeeper::{Gatekeeper, MaxSlotsReached, UserInfo};
 use crate::responder::{ConfirmationStatus, Responder, TransactionTracker};
-
-/// Data structure used to cache locators computed from parsed blocks.
-///
-/// Holds up to `size` blocks with their corresponding computed [Locator]s.
-#[derive(Debug)]
-struct LocatorCache {
-    /// A [Locator]:[Transaction] map.
-    cache: HashMap<Locator, Transaction>,
-    /// Vector of block hashes corresponding to the cached blocks.
-    blocks: Vec<BlockHash>,
-    /// Map of [BlockHash]:[Vec<Locator>]. Used to remove data from the cache.
-    tx_in_block: HashMap<BlockHash, Vec<Locator>>,
-    /// Maximum size of the cache.
-    size: usize,
-}
-
-impl fmt::Display for LocatorCache {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "cache: {:?}\n\nblocks: {:?}\n\ntx_in_block: {:?}\n\nsize: {}",
-            self.cache, self.blocks, self.tx_in_block, self.size
-        )
-    }
-}
-
-impl LocatorCache {
-    /// Creates a new [LocatorCache] instance.
-    /// The cache is initialized using the provided vector of blocks.
-    /// The size of the cache is defined as the size of `last_n_blocks`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any of the blocks in `last_n_blocks` is unchained. That is, if the given blocks
-    /// are not linked in strict descending order.
-    fn new(last_n_blocks: Vec<ValidatedBlock>) -> LocatorCache {
-        let size = last_n_blocks.len();
-        let mut cache = LocatorCache {
-            cache: HashMap::new(),
-            blocks: Vec::with_capacity(size),
-            tx_in_block: HashMap::new(),
-            size,
-        };
-
-        for block in last_n_blocks.into_iter().rev() {
-            if let Some(prev_block_hash) = cache.blocks.last() {
-                if block.header.prev_blockhash != *prev_block_hash {
-                    panic!("last_n_blocks contains unchained blocks");
-                }
-            };
-
-            let locator_tx_map = block
-                .txdata
-                .iter()
-                .map(|tx| (Locator::new(tx.txid()), tx.clone()))
-                .collect();
-
-            cache.update(block.header, &locator_tx_map);
-        }
-
-        cache
-    }
-
-    /// Gets a transaction from the cache if present. [None] otherwise.
-    fn get_tx(&self, locator: Locator) -> Option<&Transaction> {
-        self.cache.get(&locator)
-    }
-
-    /// Checks if the cache if full.
-    fn is_full(&self) -> bool {
-        self.blocks.len() > self.size
-    }
-
-    /// Updates the cache by adding data from a new block. Removes the oldest block if the cache is full afterwards.
-    fn update(
-        &mut self,
-        block_header: BlockHeader,
-        locator_tx_map: &HashMap<Locator, Transaction>,
-    ) {
-        self.blocks.push(block_header.block_hash());
-
-        let locators = locator_tx_map
-            .iter()
-            .map(|(l, tx)| {
-                self.cache.insert(*l, tx.clone());
-                *l
-            })
-            .collect();
-
-        self.tx_in_block.insert(block_header.block_hash(), locators);
-
-        if self.is_full() {
-            // Avoid logging during bootstrap
-            log::info!("New block added to cache: {}", block_header.block_hash());
-            self.remove_oldest_block();
-        }
-    }
-
-    /// Fixes the [LocatorCache] removing disconnected data.
-    fn fix(&mut self, header: &BlockHeader) {
-        if let Some(locators) = self.tx_in_block.remove(&header.block_hash()) {
-            for locator in locators.iter() {
-                self.cache.remove(locator);
-            }
-
-            // Blocks should be disconnected from last backwards. Log if that's not the case so we can revisit this and fix it.
-            if let Some(h) = self.blocks.pop() {
-                if h != header.block_hash() {
-                    log::error!("Disconnected block does not match the oldest block stored in the LocatorCache ({} != {})", header.block_hash(), h);
-                }
-            }
-        } else {
-            log::warn!("The cache is already empty");
-        }
-    }
-
-    /// Removes the oldest block from the cache.
-    /// This removes data from `self.blocks`, `self.tx_in_block` and `self.cache`.
-    fn remove_oldest_block(&mut self) {
-        let oldest_hash = self.blocks.remove(0);
-        for locator in self.tx_in_block.remove(&oldest_hash).unwrap() {
-            self.cache.remove(&locator);
-        }
-
-        log::info!("Oldest block removed from cache: {}", oldest_hash);
-    }
-}
+use crate::tx_index::TxIndex;
 
 /// Structure holding data regarding a breach.
 ///
@@ -241,7 +113,7 @@ pub struct Watcher {
     /// A map between [Locator]s (user identifiers for [Appointment]s) and [UUID]s (tower identifiers).
     locator_uuid_map: Mutex<HashMap<Locator, HashSet<UUID>>>,
     /// A cache of the [Locator]s computed for the transactions in the last few blocks.
-    locator_cache: Mutex<LocatorCache>,
+    locator_cache: Mutex<TxIndex<Locator, Transaction>>,
     /// A [Responder] instance. Data will be passed to it once triggered (if valid).
     responder: Arc<Responder>,
     /// A [Gatekeeper] instance. Data regarding users is requested to it.
@@ -261,7 +133,7 @@ impl Watcher {
     pub fn new(
         gatekeeper: Arc<Gatekeeper>,
         responder: Arc<Responder>,
-        last_n_blocks: Vec<ValidatedBlock>,
+        last_n_blocks: &[ValidatedBlock],
         last_known_block_height: u32,
         signing_key: SecretKey,
         tower_id: TowerId,
@@ -282,7 +154,7 @@ impl Watcher {
         Watcher {
             appointments: Mutex::new(appointments),
             locator_uuid_map: Mutex::new(locator_uuid_map),
-            locator_cache: Mutex::new(LocatorCache::new(last_n_blocks)),
+            locator_cache: Mutex::new(TxIndex::new(last_n_blocks, last_known_block_height)),
             responder,
             gatekeeper,
             last_known_block_height: AtomicU32::new(last_known_block_height),
@@ -362,7 +234,7 @@ impl Watcher {
             .locator_cache
             .lock()
             .unwrap()
-            .get_tx(extended_appointment.locator())
+            .get(&extended_appointment.locator())
         {
             // Appointments that were triggered in blocks held in the cache
             Some(dispute_tx) => {
@@ -879,7 +751,10 @@ impl chain::Listen for Watcher {
     /// Fixes the [LocatorCache] by removing the disconnected data and updates the last_known_block_height.
     fn block_disconnected(&self, header: &BlockHeader, height: u32) {
         log::warn!("Block disconnected: {}", header.block_hash());
-        self.locator_cache.lock().unwrap().fix(header);
+        self.locator_cache
+            .lock()
+            .unwrap()
+            .remove_disconnected_block(&header.block_hash());
         self.last_known_block_height
             .store(height - 1, Ordering::Release);
     }
@@ -980,122 +855,6 @@ mod tests {
         let recovered_pk =
             cryptography::recover_pk(&receipt.to_vec(), &receipt.signature().unwrap()).unwrap();
         assert_eq!(TowerId(recovered_pk), tower_id);
-    }
-
-    #[tokio::test]
-    async fn test_cache_new() {
-        let mut chain = Blockchain::default().with_height(10);
-        let last_six_blocks = get_last_n_blocks(&mut chain, 6).await;
-        let blocks: Vec<Block> = last_six_blocks
-            .iter()
-            .map(|block| block.deref().clone())
-            .collect();
-
-        let cache = LocatorCache::new(last_six_blocks);
-        assert_eq!(blocks.len(), cache.size);
-        for block in blocks.iter() {
-            assert!(cache.blocks.contains(&block.block_hash()));
-
-            let mut locators = Vec::new();
-            for tx in block.txdata.iter() {
-                let locator = Locator::new(tx.txid());
-                assert!(cache.cache.contains_key(&locator));
-                locators.push(locator);
-            }
-
-            assert_eq!(cache.tx_in_block[&block.block_hash()], locators);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_cache_update() {
-        let mut chain = Blockchain::default().with_height(10);
-        let mut last_n_blocks = get_last_n_blocks(&mut chain, 7).await;
-
-        // Safe the last block to use it for an update and the first to check eviction
-        // Notice that the list of blocks is ordered from last to first.
-        let last_block = last_n_blocks.remove(0);
-        let first_block = last_n_blocks.last().unwrap().deref().clone();
-
-        // Init the cache with the 6 block before the last
-        let mut cache = LocatorCache::new(last_n_blocks);
-
-        // Update the cache with the last block
-        let locator_tx_map = last_block
-            .txdata
-            .iter()
-            .map(|tx| (Locator::new(tx.txid()), tx.clone()))
-            .collect();
-
-        cache.update(last_block.deref().header, &locator_tx_map);
-
-        // Check that the new data is in the cache
-        assert!(cache.blocks.contains(&last_block.block_hash()));
-        for (locator, _) in locator_tx_map.iter() {
-            assert!(cache.cache.contains_key(locator));
-        }
-        assert_eq!(
-            cache.tx_in_block[&last_block.block_hash()],
-            locator_tx_map.keys().cloned().collect::<Vec<Locator>>()
-        );
-
-        // Check that the data from the first block has been evicted
-        assert!(!cache.blocks.contains(&first_block.block_hash()));
-        for tx in first_block.txdata.iter() {
-            assert!(!cache.cache.contains_key(&Locator::new(tx.txid())));
-        }
-        assert!(!cache.tx_in_block.contains_key(&first_block.block_hash()));
-    }
-
-    #[tokio::test]
-    async fn test_cache_fix() {
-        let cache_size = 6;
-        let mut chain = Blockchain::default().with_height_and_txs(cache_size * 2, 42);
-
-        let last_n_blocks = get_last_n_blocks(&mut chain, cache_size).await;
-
-        // Init the cache with the 6 block before the last
-        let mut cache = LocatorCache::new(last_n_blocks);
-
-        // LocatorCache::fix removes the last connected block and removes all the associated data
-        for i in 0..cache_size {
-            let header = chain
-                .at_height(chain.get_block_count() as usize - i)
-                .deref()
-                .header;
-            let locators = cache.tx_in_block.get(&header.block_hash()).unwrap().clone();
-
-            // Make sure there's data regarding the target block in the cache before fixing it
-            assert_eq!(cache.blocks.len(), cache.size - i);
-            assert!(cache.blocks.contains(&header.block_hash()));
-            assert!(!locators.is_empty());
-            for locator in locators.iter() {
-                assert!(cache.cache.contains_key(locator));
-            }
-
-            cache.fix(&header);
-
-            // Check that the block data is not in the cache anymore
-            assert_eq!(cache.blocks.len(), cache.size - i - 1);
-            assert!(!cache.blocks.contains(&header.block_hash()));
-            assert!(cache.tx_in_block.get(&header.block_hash()).is_none());
-            for locator in locators.iter() {
-                assert!(!cache.cache.contains_key(locator));
-            }
-        }
-
-        // At this point the cache should be empty, fixing it further shouldn't do anything
-        for i in cache_size..cache_size * 2 {
-            assert!(cache.cache.is_empty());
-            assert!(cache.blocks.is_empty());
-            assert!(cache.tx_in_block.is_empty());
-
-            let header = chain
-                .at_height(chain.get_block_count() as usize - i)
-                .deref()
-                .header;
-            cache.fix(&header);
-        }
     }
 
     #[tokio::test]
@@ -2122,7 +1881,7 @@ mod tests {
             .locator_cache
             .lock()
             .unwrap()
-            .blocks
+            .blocks()
             .contains(&last_block_header.block_hash()));
 
         watcher.block_disconnected(&last_block_header, start_height);
@@ -2135,7 +1894,7 @@ mod tests {
             .locator_cache
             .lock()
             .unwrap()
-            .blocks
+            .blocks()
             .contains(&last_block_header.block_hash()));
     }
 }

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -771,10 +771,10 @@ mod tests {
     use crate::rpc_errors;
     use crate::test_utils::{
         create_carrier, create_responder, create_watcher, generate_dummy_appointment,
-        generate_dummy_appointment_with_user, generate_uuid, get_last_n_blocks, get_random_breach,
-        get_random_tx, store_appointment_and_fks_to_db, BitcoindMock, BitcoindStopper, Blockchain,
-        MockOptions, MockedServerQuery, AVAILABLE_SLOTS, DURATION, EXPIRY_DELTA, SLOTS,
-        START_HEIGHT, SUBSCRIPTION_EXPIRY, SUBSCRIPTION_START,
+        generate_dummy_appointment_with_user, generate_uuid, get_random_breach, get_random_tx,
+        store_appointment_and_fks_to_db, BitcoindMock, BitcoindStopper, Blockchain, MockOptions,
+        MockedServerQuery, AVAILABLE_SLOTS, DURATION, EXPIRY_DELTA, SLOTS, START_HEIGHT,
+        SUBSCRIPTION_EXPIRY, SUBSCRIPTION_START,
     };
     use teos_common::cryptography::{get_random_bytes, get_random_keypair};
     use teos_common::dbm::Error as DBError;
@@ -782,7 +782,7 @@ mod tests {
     use bitcoin::hash_types::Txid;
     use bitcoin::hashes::Hash;
     use bitcoin::secp256k1::{PublicKey, Secp256k1};
-    use bitcoin::Block;
+
     use lightning::chain::Listen;
 
     impl PartialEq for Watcher {
@@ -820,7 +820,7 @@ mod tests {
         chain: &mut Blockchain,
         dbm: Arc<Mutex<DBM>>,
     ) -> (Watcher, BitcoindStopper) {
-        let bitcoind_mock = BitcoindMock::new(MockOptions::empty());
+        let bitcoind_mock = BitcoindMock::new(MockOptions::default());
 
         let gk = Arc::new(Gatekeeper::new(
             chain.get_block_count(),
@@ -829,7 +829,7 @@ mod tests {
             EXPIRY_DELTA,
             dbm.clone(),
         ));
-        let responder = create_responder(chain.tip(), gk.clone(), dbm.clone(), bitcoind_mock.url());
+        let responder = create_responder(chain, gk.clone(), dbm.clone(), bitcoind_mock.url()).await;
         create_watcher(
             chain,
             Arc::new(responder),


### PR DESCRIPTION
Generalizes the `Watcher`'s `LocatorCache` into a `TxIndex` that can be used both by the `Watcher` and the `Responder`. The former does use it in the same way as before (as a `LocatorCache` to keep track of the `Locators` of the last n blocks). As for the latter, it is used to implement a pruned transaction index (a `Txid`:`BlockHash` map).

By adding this `TxIndex` in the `Responder` we don't have to run `bitcoind` with `txindex=1` anymore and, therefore, we are able to reduce the initial storage requirements significantly: from ~420 GB on disk at the time of writing to a few dozen KB in memory.

With this new approach queries to past transactions will be performed internally instead of against `bitcoind` in most cases. If a transaction cannot be found in our index nor in mempool it'll mean that it was confirmed long ago (confirmation count > our `TxIndex` length). The `Responder` index is set to be `IRREVOCABLY_RESOLVED` blocks long, meaning that if we don't find a transaction on it we don't need to care anyway.