### PR TITLE
Adds named arguments to CoreLN plugin

### DIFF
--- a/teos-common/src/lib.rs
+++ b/teos-common/src/lib.rs
@@ -22,6 +22,7 @@ use std::fmt;
 use std::{convert::TryFrom, str::FromStr};
 
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use bitcoin::secp256k1::{Error, PublicKey};
 
@@ -79,10 +80,111 @@ impl TryFrom<serde_json::Value> for UserId {
                     ))
                 }
             }
+            serde_json::Value::Object(mut m) => {
+                let param_count = m.len();
+                if param_count > 1 {
+                    Err(format!(
+                        "Unexpected json format. Expected a single parameter. Received: {}",
+                        param_count
+                    ))
+                } else {
+                    UserId::try_from(json!(m
+                        .remove("user_id")
+                        .or_else(|| m.remove("tower_id"))
+                        .ok_or("user_id or tower_id not found")?))
+                }
+            }
             _ => Err(format!(
                 "Unexpected request format. Expected: user_id/tower_id. Received: '{}'",
                 value
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    use crate::test_utils::get_random_user_id;
+
+    #[test]
+    fn try_from_json_string() {
+        let user_id = get_random_user_id();
+        assert_eq!(UserId::try_from(json!(user_id.to_string())), Ok(user_id));
+    }
+
+    #[test]
+    fn try_from_json_wrong_string() {
+        let user_id = "not_a_user_id";
+        assert!(matches!(
+            UserId::try_from(json!(user_id.to_string())),
+            Err(..)
+        ));
+    }
+
+    #[test]
+    fn try_from_json_array() {
+        let user_id = get_random_user_id();
+        assert_eq!(UserId::try_from(json!([user_id.to_string()])), Ok(user_id));
+    }
+
+    #[test]
+    fn try_from_json_array_empty() {
+        assert!(matches!(UserId::try_from(json!([])), Err(..)));
+    }
+
+    #[test]
+    fn try_from_json_array_too_many_elements() {
+        let user_id = get_random_user_id();
+        assert!(matches!(
+            UserId::try_from(json!([user_id.to_string(), user_id.to_string()])),
+            Err(..)
+        ));
+    }
+
+    #[test]
+    fn try_from_json_dict() {
+        let user_id = get_random_user_id();
+        assert_eq!(
+            UserId::try_from(json!(HashMap::from([("tower_id", user_id.to_string())]))),
+            Ok(user_id)
+        );
+        assert_eq!(
+            UserId::try_from(json!(HashMap::from([("user_id", user_id.to_string())]))),
+            Ok(user_id)
+        );
+    }
+
+    #[test]
+    fn try_from_json_empty_dict() {
+        assert!(matches!(
+            UserId::try_from(json!(HashMap::<String, serde_json::Value>::new())),
+            Err(..)
+        ));
+    }
+
+    #[test]
+    fn try_from_json_wrong_dict() {
+        let user_id = get_random_user_id();
+        assert!(matches!(
+            UserId::try_from(json!(HashMap::from([("random_key", user_id.to_string())]))),
+            Err(..)
+        ));
+    }
+
+    #[test]
+    fn try_from_json_dict_too_many_keys() {
+        let user_id = get_random_user_id();
+
+        assert!(matches!(
+            UserId::try_from(json!(HashMap::from([
+                ("tower_id", user_id.to_string()),
+                ("user_id", user_id.to_string())
+            ]))),
+            Err(..)
+        ));
     }
 }

--- a/watchtower-plugin/src/net/http.rs
+++ b/watchtower-plugin/src/net/http.rs
@@ -177,7 +177,7 @@ pub async fn post_request<S: Serialize>(
     };
 
     client.post(endpoint).json(&data).send().await.map_err(|e| {
-        log::debug!("POST request failed: {:?}", e);
+        log::debug!("An error ocurred when sending data to the tower: {}", e);
         if e.is_connect() | e.is_timeout() {
             RequestError::ConnectionError(
                 "Cannot connect to the tower. Connection refused".to_owned(),


### PR DESCRIPTION
CoreLN supports named parameters for their RPC commands when passing `-k` to the call. e.g:

`lightning-cli -k <command> arg_0=val_0...arg_n=val_n`

Add support for our plugin so it's easier to tackle #69 