### PR TITLE
Minor improvements regarding Strings in cln-plugin

### DIFF
--- a/watchtower-plugin/src/convert.rs
+++ b/watchtower-plugin/src/convert.rs
@@ -55,7 +55,7 @@ impl RegisterParams {
     fn from_id(tower_id: &str) -> Result<Self, RegisterError> {
         Ok(Self {
             tower_id: TowerId::from_str(tower_id)
-                .map_err(|_| RegisterError::InvalidId("Invalid tower id".into()))?,
+                .map_err(|_| RegisterError::InvalidId("Invalid tower id".to_owned()))?,
             host: None,
             port: None,
         })
@@ -63,10 +63,10 @@ impl RegisterParams {
 
     fn with_host(self, host: &str) -> Result<Self, RegisterError> {
         if host.is_empty() {
-            Err(RegisterError::InvalidHost("hostname is empty".into()))
+            Err(RegisterError::InvalidHost("hostname is empty".to_owned()))
         } else if host.contains(' ') {
             Err(RegisterError::InvalidHost(
-                "hostname contains white spaces".into(),
+                "hostname contains white spaces".to_owned(),
             ))
         } else {
             Ok(Self {
@@ -193,21 +193,22 @@ impl TryFrom<serde_json::Value> for GetAppointmentParams {
                     )))
                 } else {
                     let tower_id = if let Some(s) = a.get(0).unwrap().as_str() {
-                        TowerId::from_str(s)
-                            .map_err(|_| GetAppointmentError::InvalidId("Invalid tower id".into()))
+                        TowerId::from_str(s).map_err(|_| {
+                            GetAppointmentError::InvalidId("Invalid tower id".to_owned())
+                        })
                     } else {
                         Err(GetAppointmentError::InvalidId(
-                            "tower_id must be a hex encoded string".into(),
+                            "tower_id must be a hex encoded string".to_owned(),
                         ))
                     }?;
 
                     let locator = if let Some(s) = a.get(1).unwrap().as_str() {
                         Locator::from_hex(s).map_err(|_| {
-                            GetAppointmentError::InvalidLocator("Invalid locator".into())
+                            GetAppointmentError::InvalidLocator("Invalid locator".to_owned())
                         })
                     } else {
                         Err(GetAppointmentError::InvalidLocator(
-                            "locator must be a hex encoded string".into(),
+                            "locator must be a hex encoded string".to_owned(),
                         ))
                     }?;
 
@@ -262,7 +263,7 @@ mod tests {
             // Any properly formatted host should work
             let params = RegisterParams::from_id(VALID_ID).unwrap();
             let host = "myhost";
-            assert_eq!(params.with_host(host).unwrap().host, Some(host.into()));
+            assert_eq!(params.with_host(host).unwrap().host, Some(host.to_owned()));
 
             // Host must not be empty not have spaces
             assert!(matches!(

--- a/watchtower-plugin/src/dbm.rs
+++ b/watchtower-plugin/src/dbm.rs
@@ -705,7 +705,7 @@ mod tests {
 
         let receipt = get_random_registration_receipt();
         let tower_info = TowerInfo::new(
-            net_addr.into(),
+            net_addr.to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
@@ -821,7 +821,7 @@ mod tests {
             towers.insert(
                 tower_id,
                 TowerSummary::new(
-                    net_addr.into(),
+                    net_addr.to_owned(),
                     receipt.available_slots(),
                     receipt.subscription_start(),
                     receipt.subscription_expiry(),
@@ -872,7 +872,7 @@ mod tests {
 
         let receipt = get_random_registration_receipt();
         let mut tower_summary = TowerSummary::new(
-            net_addr.into(),
+            net_addr.to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
@@ -886,9 +886,9 @@ mod tests {
             let appointment = generate_random_appointment(None);
             let user_signature = "user_signature";
             let appointment_receipt = AppointmentReceipt::with_signature(
-                user_signature.into(),
+                user_signature.to_owned(),
                 42,
-                "tower_signature".into(),
+                "tower_signature".to_owned(),
             );
 
             tower_summary.available_slots -= 1;
@@ -935,15 +935,15 @@ mod tests {
 
         // Add both
         let tower_summary = TowerSummary::new(
-            net_addr.into(),
+            net_addr.to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
         );
         let appointment_receipt = AppointmentReceipt::with_signature(
-            "user_signature".into(),
+            "user_signature".to_owned(),
             42,
-            "tower_signature".into(),
+            "tower_signature".to_owned(),
         );
         dbm.store_appointment_receipt(
             tower_id,
@@ -971,7 +971,7 @@ mod tests {
 
         let receipt = get_random_registration_receipt();
         let tower_summary = TowerSummary::new(
-            net_addr.into(),
+            net_addr.to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
@@ -987,9 +987,9 @@ mod tests {
         for _ in 0..5 {
             let appointment = generate_random_appointment(None);
             let appointment_receipt = AppointmentReceipt::with_signature(
-                user_signature.into(),
+                user_signature.to_owned(),
                 42,
-                "tower_signature".into(),
+                "tower_signature".to_owned(),
             );
             let pending_appointment = generate_random_appointment(None);
             let invalid_appointment = generate_random_appointment(None);
@@ -1058,7 +1058,7 @@ mod tests {
 
         let receipt = get_random_registration_receipt();
         let mut tower_summary = TowerSummary::new(
-            net_addr.into(),
+            net_addr.to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
@@ -1188,7 +1188,7 @@ mod tests {
 
         let receipt = get_random_registration_receipt();
         let mut tower_summary = TowerSummary::new(
-            net_addr.into(),
+            net_addr.to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
@@ -1251,7 +1251,7 @@ mod tests {
 
         let receipt = get_random_registration_receipt();
         let tower_summary = TowerSummary::new(
-            net_addr.into(),
+            net_addr.to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
@@ -1266,9 +1266,9 @@ mod tests {
         // Store a misbehaving proof and load it back
         let appointment = generate_random_appointment(None);
         let appointment_receipt = AppointmentReceipt::with_signature(
-            "user_signature".into(),
+            "user_signature".to_owned(),
             42,
-            "tower_signature".into(),
+            "tower_signature".to_owned(),
         );
 
         let proof = MisbehaviorProof::new(
@@ -1300,7 +1300,7 @@ mod tests {
 
         let receipt = get_random_registration_receipt();
         let tower_summary = TowerSummary::new(
-            net_addr.into(),
+            net_addr.to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
@@ -1315,9 +1315,9 @@ mod tests {
         // // Store a misbehaving proof check
         let appointment = generate_random_appointment(None);
         let appointment_receipt = AppointmentReceipt::with_signature(
-            "user_signature".into(),
+            "user_signature".to_owned(),
             42,
-            "tower_signature".into(),
+            "tower_signature".to_owned(),
         );
 
         let proof = MisbehaviorProof::new(

--- a/watchtower-plugin/src/lib.rs
+++ b/watchtower-plugin/src/lib.rs
@@ -312,7 +312,7 @@ mod tests {
 
         #[test]
         fn test_new() {
-            let net_addr: String = "addr".into();
+            let net_addr: String = "addr".to_owned();
 
             let tower_summary = TowerSummary::new(
                 net_addr.clone(),
@@ -336,7 +336,7 @@ mod tests {
 
         #[test]
         fn test_with_appointments() {
-            let net_addr: String = "addr".into();
+            let net_addr: String = "addr".to_owned();
 
             let pending_appointments =
                 HashSet::from_iter([generate_random_appointment(None).locator]);
@@ -368,7 +368,7 @@ mod tests {
         #[test]
         fn test_with_status() {
             let mut tower_summary = TowerSummary::new(
-                "addr".into(),
+                "addr".to_owned(),
                 AVAILABLE_SLOTS,
                 SUBSCRIPTION_START,
                 SUBSCRIPTION_EXPIRY,
@@ -407,7 +407,7 @@ mod tests {
         #[test]
         fn test_new() {
             let tower_info = TowerInfo::new(
-                "addr".into(),
+                "addr".to_owned(),
                 AVAILABLE_SLOTS,
                 SUBSCRIPTION_START,
                 SUBSCRIPTION_EXPIRY,
@@ -423,7 +423,7 @@ mod tests {
         #[test]
         fn test_with_status() {
             let mut tower_info = TowerInfo::empty(
-                "addr".into(),
+                "addr".to_owned(),
                 AVAILABLE_SLOTS,
                 SUBSCRIPTION_START,
                 SUBSCRIPTION_EXPIRY,
@@ -437,7 +437,7 @@ mod tests {
         #[test]
         fn test_set_misbehaving_proof() {
             let mut tower_info = TowerInfo::empty(
-                "addr".into(),
+                "addr".to_owned(),
                 AVAILABLE_SLOTS,
                 SUBSCRIPTION_START,
                 SUBSCRIPTION_EXPIRY,
@@ -445,9 +445,9 @@ mod tests {
             assert_eq!(tower_info.misbehaving_proof, None);
 
             let appointment_receipt = AppointmentReceipt::with_signature(
-                "user_signature".into(),
+                "user_signature".to_owned(),
                 SUBSCRIPTION_START + 1,
-                "tower_signature".into(),
+                "tower_signature".to_owned(),
             );
             let proof = MisbehaviorProof::new(
                 generate_random_appointment(None).locator,

--- a/watchtower-plugin/src/main.rs
+++ b/watchtower-plugin/src/main.rs
@@ -115,7 +115,7 @@ async fn register(
         .state()
         .lock()
         .unwrap()
-        .add_update_tower(tower_id, tower_net_addr, &receipt).map_err(|e| {
+        .add_update_tower(tower_id, &tower_net_addr, &receipt).map_err(|e| {
             if e.is_expiry() {
                 anyhow!("Registration receipt contains a subscription expiry that is not higher than the one we are currently registered for")
             } else {

--- a/watchtower-plugin/src/main.rs
+++ b/watchtower-plugin/src/main.rs
@@ -46,7 +46,7 @@ async fn register(
     v: serde_json::Value,
 ) -> Result<serde_json::Value, Error> {
     let params = RegisterParams::try_from(v).map_err(|x| anyhow!(x))?;
-    let host = params.host.unwrap_or_else(|| "localhost".into());
+    let host = params.host.unwrap_or_else(|| "localhost".to_owned());
     let tower_id = params.tower_id;
     let user_id = plugin.state().lock().unwrap().user_id;
 

--- a/watchtower-plugin/src/net/http.rs
+++ b/watchtower-plugin/src/net/http.rs
@@ -84,7 +84,7 @@ pub async fn send_appointment(
 ) -> Result<(common_msgs::AddAppointmentResponse, AppointmentReceipt), AddAppointmentError> {
     let request_data = common_msgs::AddAppointmentRequest {
         appointment: Some(appointment.clone().into()),
-        signature: signature.into(),
+        signature: signature.to_owned(),
     };
 
     match process_post_response(
@@ -99,7 +99,7 @@ pub async fn send_appointment(
     {
         ApiResponse::Response::<common_msgs::AddAppointmentResponse>(r) => {
             let receipt = AppointmentReceipt::with_signature(
-                signature.into(),
+                signature.to_owned(),
                 r.start_block,
                 r.signature.clone(),
             );
@@ -139,7 +139,7 @@ pub async fn post_request<S: Serialize>(
                 .map_err(|e| RequestError::ConnectionError(format!("{}", e)))?
         } else {
             return Err(RequestError::ConnectionError(
-                "Cannot connect to an onion address without a proxy".into(),
+                "Cannot connect to an onion address without a proxy".to_owned(),
             ));
         }
     } else {
@@ -149,9 +149,11 @@ pub async fn post_request<S: Serialize>(
     client.post(endpoint).json(&data).send().await.map_err(|e| {
         log::debug!("POST request failed: {:?}", e);
         if e.is_connect() | e.is_timeout() {
-            RequestError::ConnectionError("Cannot connect to the tower. Connection refused".into())
+            RequestError::ConnectionError(
+                "Cannot connect to the tower. Connection refused".to_owned(),
+            )
         } else {
-            RequestError::Unexpected("Unexpected error ocurred (see logs for more info)".into())
+            RequestError::Unexpected("Unexpected error ocurred (see logs for more info)".to_owned())
         }
     })
 }
@@ -187,11 +189,11 @@ mod tests {
         fn test_is_connection() {
             let error_message = "error_msg";
             for error in [
-                RequestError::ConnectionError(error_message.into()),
-                RequestError::DeserializeError(error_message.into()),
-                RequestError::Unexpected(error_message.into()),
+                RequestError::ConnectionError(error_message.to_owned()),
+                RequestError::DeserializeError(error_message.to_owned()),
+                RequestError::Unexpected(error_message.to_owned()),
             ] {
-                if error == RequestError::ConnectionError(error_message.into()) {
+                if error == RequestError::ConnectionError(error_message.to_owned()) {
                     assert!(error.is_connection())
                 } else {
                     assert!(!error.is_connection())
@@ -359,7 +361,7 @@ mod tests {
     #[tokio::test]
     async fn test_send_appointment_api_error() {
         let api_error = ApiError {
-            error: "error_msg".into(),
+            error: "error_msg".to_owned(),
             error_code: 1,
         };
 

--- a/watchtower-plugin/src/retrier.rs
+++ b/watchtower-plugin/src/retrier.rs
@@ -400,7 +400,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .add_update_tower(tower_id, &server.base_url(), &receipt)
             .unwrap();
 
         // Add appointment to pending
@@ -537,7 +537,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .add_update_tower(tower_id, &server.base_url(), &receipt)
             .unwrap();
 
         // Add appointment to pending
@@ -616,7 +616,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .add_update_tower(tower_id, &server.base_url(), &receipt)
             .unwrap();
 
         // Add appointment to pending
@@ -682,7 +682,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .add_update_tower(tower_id, &server.base_url(), &receipt)
             .unwrap();
 
         // Remove the tower (to simulate it has been abandoned)
@@ -720,7 +720,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .add_update_tower(tower_id, &server.base_url(), &receipt)
             .unwrap();
 
         // Add appointment to pending
@@ -767,7 +767,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .add_update_tower(tower_id, &server.base_url(), &receipt)
             .unwrap();
 
         // If there are no pending appointments the method will simply return
@@ -790,7 +790,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .add_update_tower(tower_id, &server.base_url(), &receipt)
             .unwrap();
 
         // Add appointment to pending
@@ -868,7 +868,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .add_update_tower(tower_id, &server.base_url(), &receipt)
             .unwrap();
 
         let api_mock = server.mock(|when, then| {
@@ -911,7 +911,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .add_update_tower(tower_id, &server.base_url(), &receipt)
             .unwrap();
 
         let api_mock = server.mock(|when, then| {
@@ -962,7 +962,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, server.base_url(), &receipt)
+            .add_update_tower(tower_id, &server.base_url(), &receipt)
             .unwrap();
 
         // Remove the tower (to simulate it has been abandoned)

--- a/watchtower-plugin/src/retrier.rs
+++ b/watchtower-plugin/src/retrier.rs
@@ -475,7 +475,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, "http://unreachable.tower".into(), &receipt)
+            .add_update_tower(tower_id, "http://unreachable.tower", &receipt)
             .unwrap();
 
         // Add appointment to pending
@@ -553,7 +553,7 @@ mod tests {
             then.status(400)
                 .header("content-type", "application/json")
                 .json_body(json!(ApiError {
-                    error: "error_msg".into(),
+                    error: "error_msg".to_owned(),
                     error_code: 1,
                 }));
         });
@@ -836,7 +836,7 @@ mod tests {
         wt_client
             .lock()
             .unwrap()
-            .add_update_tower(tower_id, "http://unreachable.tower".into(), &receipt)
+            .add_update_tower(tower_id, "http://unreachable.tower", &receipt)
             .unwrap();
 
         // Add some pending appointments and try again (with an unreachable tower).
@@ -876,7 +876,7 @@ mod tests {
             then.status(400)
                 .header("content-type", "application/json")
                 .json_body(json!(ApiError {
-                    error: "error_msg".into(),
+                    error: "error_msg".to_owned(),
                     error_code: errors::INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR,
                 }));
         });
@@ -919,7 +919,7 @@ mod tests {
             then.status(400)
                 .header("content-type", "application/json")
                 .json_body(json!(ApiError {
-                    error: "error_msg".into(),
+                    error: "error_msg".to_owned(),
                     error_code: 1,
                 }));
         });

--- a/watchtower-plugin/src/wt_client.rs
+++ b/watchtower-plugin/src/wt_client.rs
@@ -103,7 +103,7 @@ impl WTClient {
         }
 
         self.dbm
-            .store_tower_record(tower_id, &tower_net_addr, receipt)
+            .store_tower_record(tower_id, tower_net_addr, receipt)
             .unwrap();
         self.towers.insert(
             tower_id,
@@ -270,7 +270,7 @@ mod tests {
         let mut receipt = get_random_registration_receipt();
         let tower_id = get_random_user_id();
         let tower_info = TowerInfo::empty(
-            "talaia.watch".into(),
+            "talaia.watch".to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
@@ -289,7 +289,7 @@ mod tests {
         receipt = get_registration_receipt_from_previous(&receipt);
 
         let updated_tower_info = TowerInfo::empty(
-            "talaia.watch".into(),
+            "talaia.watch".to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
@@ -354,7 +354,7 @@ mod tests {
         let receipt = get_random_registration_receipt();
         let tower_id = get_random_user_id();
         wt_client
-            .add_update_tower(tower_id, "talaia.watch".into(), &receipt)
+            .add_update_tower(tower_id, "talaia.watch", &receipt)
             .unwrap();
 
         for status in [
@@ -377,7 +377,7 @@ mod tests {
 
         let (tower_sk, tower_pk) = cryptography::get_random_keypair();
         let tower_id = TowerId(tower_pk);
-        let tower_net_addr = "talaia.watch";
+        let tower_net_addr = "talaia.watch".to_owned();
 
         let locator = generate_random_appointment(None).locator;
         let registration_receipt = get_random_registration_receipt();
@@ -394,7 +394,7 @@ mod tests {
 
         // Add the tower to the state and try again
         let tower_info = TowerInfo::new(
-            tower_net_addr.into(),
+            tower_net_addr.clone(),
             registration_receipt.available_slots(),
             registration_receipt.subscription_start(),
             registration_receipt.subscription_expiry(),
@@ -403,7 +403,7 @@ mod tests {
             Vec::new(),
         );
         wt_client
-            .add_update_tower(tower_id, tower_net_addr.into(), &registration_receipt)
+            .add_update_tower(tower_id, &tower_net_addr, &registration_receipt)
             .unwrap();
         wt_client.add_appointment_receipt(
             tower_id,
@@ -427,7 +427,7 @@ mod tests {
             WTClient::new(tmp_path.path().to_path_buf(), unbounded_channel().0).await;
 
         let tower_id = get_random_user_id();
-        let tower_net_addr = "talaia.watch";
+        let tower_net_addr = "talaia.watch".to_owned();
 
         let registration_receipt = get_random_registration_receipt();
         let appointment = generate_random_appointment(None);
@@ -438,7 +438,7 @@ mod tests {
 
         // Add the tower to the state and try again
         let tower_info = TowerInfo::new(
-            tower_net_addr.into(),
+            tower_net_addr.clone(),
             registration_receipt.available_slots(),
             registration_receipt.subscription_start(),
             registration_receipt.subscription_expiry(),
@@ -448,7 +448,7 @@ mod tests {
         );
 
         wt_client
-            .add_update_tower(tower_id, tower_net_addr.into(), &registration_receipt)
+            .add_update_tower(tower_id, &tower_net_addr, &registration_receipt)
             .unwrap();
         wt_client.add_pending_appointment(tower_id, &appointment);
 
@@ -471,7 +471,7 @@ mod tests {
             WTClient::new(tmp_path.path().to_path_buf(), unbounded_channel().0).await;
 
         let tower_id = get_random_user_id();
-        let tower_net_addr = "talaia.watch";
+        let tower_net_addr = "talaia.watch".to_owned();
 
         let registration_receipt = get_random_registration_receipt();
         let appointment = generate_random_appointment(None);
@@ -481,7 +481,7 @@ mod tests {
 
         // Add the tower to the state and try again
         wt_client
-            .add_update_tower(tower_id, tower_net_addr.into(), &registration_receipt)
+            .add_update_tower(tower_id, &tower_net_addr, &registration_receipt)
             .unwrap();
         wt_client.add_pending_appointment(tower_id, &appointment);
 
@@ -503,7 +503,7 @@ mod tests {
             WTClient::new(tmp_path.path().to_path_buf(), unbounded_channel().0).await;
 
         let tower_id = get_random_user_id();
-        let tower_net_addr = "talaia.watch";
+        let tower_net_addr = "talaia.watch".to_owned();
 
         let registration_receipt = get_random_registration_receipt();
         let appointment = generate_random_appointment(None);
@@ -514,7 +514,7 @@ mod tests {
 
         // Add the tower to the state and try again
         let tower_info = TowerInfo::new(
-            tower_net_addr.into(),
+            tower_net_addr.clone(),
             registration_receipt.available_slots(),
             registration_receipt.subscription_start(),
             registration_receipt.subscription_expiry(),
@@ -524,7 +524,7 @@ mod tests {
         );
 
         wt_client
-            .add_update_tower(tower_id, tower_net_addr.into(), &registration_receipt)
+            .add_update_tower(tower_id, &tower_net_addr, &registration_receipt)
             .unwrap();
         wt_client.add_invalid_appointment(tower_id, &appointment);
 
@@ -543,13 +543,13 @@ mod tests {
             WTClient::new(tmp_path.path().to_path_buf(), unbounded_channel().0).await;
 
         let tower_id = get_random_user_id();
-        let tower_net_addr = "talaia.watch";
+        let tower_net_addr = "talaia.watch".to_owned();
 
         let registration_receipt = get_random_registration_receipt();
         let appointment = generate_random_appointment(None);
 
         wt_client
-            .add_update_tower(tower_id, tower_net_addr.into(), &registration_receipt)
+            .add_update_tower(tower_id, &tower_net_addr, &registration_receipt)
             .unwrap();
         wt_client.add_pending_appointment(tower_id, &appointment);
 
@@ -589,20 +589,16 @@ mod tests {
 
         let tower_id = get_random_user_id();
         let another_tower_id = get_random_user_id();
-        let tower_net_addr = "talaia.watch";
+        let tower_net_addr = "talaia.watch".to_owned();
 
         let registration_receipt = get_random_registration_receipt();
         let appointment = generate_random_appointment(None);
 
         wt_client
-            .add_update_tower(tower_id, tower_net_addr.into(), &registration_receipt)
+            .add_update_tower(tower_id, &tower_net_addr, &registration_receipt)
             .unwrap();
         wt_client
-            .add_update_tower(
-                another_tower_id,
-                tower_net_addr.into(),
-                &registration_receipt,
-            )
+            .add_update_tower(another_tower_id, &tower_net_addr, &registration_receipt)
             .unwrap();
         wt_client.add_pending_appointment(tower_id, &appointment);
         wt_client.add_pending_appointment(another_tower_id, &appointment);
@@ -667,7 +663,7 @@ mod tests {
 
         let (tower_sk, tower_pk) = cryptography::get_random_keypair();
         let tower_id = TowerId(tower_pk);
-        let tower_net_addr = "talaia.watch";
+        let tower_net_addr = "talaia.watch".to_owned();
 
         // If we call this on an unknown tower it will simply do nothing
         let appointment = generate_random_appointment(None);
@@ -679,7 +675,7 @@ mod tests {
         // // Add the tower to the state and try again
         let registration_receipt = get_random_registration_receipt();
         wt_client
-            .add_update_tower(tower_id, tower_net_addr.into(), &registration_receipt)
+            .add_update_tower(tower_id, &tower_net_addr, &registration_receipt)
             .unwrap();
         wt_client.flag_misbehaving_tower(tower_id, proof.clone());
 
@@ -705,7 +701,7 @@ mod tests {
         let (tower_sk, tower_pk) = cryptography::get_random_keypair();
         let tower_id = TowerId(tower_pk);
         let tower_info = TowerInfo::empty(
-            "talaia.watch".into(),
+            "talaia.watch".to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),
@@ -773,7 +769,7 @@ mod tests {
         let tower2_id = TowerId(tower2_pk);
 
         let tower_info = TowerInfo::empty(
-            "talaia.watch".into(),
+            "talaia.watch".to_owned(),
             receipt.available_slots(),
             receipt.subscription_start(),
             receipt.subscription_expiry(),

--- a/watchtower-plugin/src/wt_client.rs
+++ b/watchtower-plugin/src/wt_client.rs
@@ -83,7 +83,7 @@ impl WTClient {
     pub fn add_update_tower(
         &mut self,
         tower_id: TowerId,
-        tower_net_addr: String,
+        tower_net_addr: &str,
         receipt: &RegistrationReceipt,
     ) -> Result<(), SubscriptionError> {
         if let Some(tower) = self.towers.get(&tower_id) {
@@ -108,7 +108,7 @@ impl WTClient {
         self.towers.insert(
             tower_id,
             TowerSummary::new(
-                tower_net_addr,
+                tower_net_addr.to_owned(),
                 receipt.available_slots(),
                 receipt.subscription_start(),
                 receipt.subscription_expiry(),
@@ -277,7 +277,7 @@ mod tests {
         );
 
         wt_client
-            .add_update_tower(tower_id, tower_info.net_addr.clone(), &receipt)
+            .add_update_tower(tower_id, &tower_info.net_addr, &receipt)
             .unwrap();
         assert_eq!(
             wt_client.towers.get(&tower_id),
@@ -295,7 +295,7 @@ mod tests {
             receipt.subscription_expiry(),
         );
         wt_client
-            .add_update_tower(tower_id, updated_tower_info.net_addr.clone(), &receipt)
+            .add_update_tower(tower_id, &updated_tower_info.net_addr, &receipt)
             .unwrap();
 
         assert_eq!(
@@ -322,19 +322,19 @@ mod tests {
         );
 
         assert!(matches!(
-            wt_client.add_update_tower(tower_id, updated_tower_info.net_addr.clone(), &receipt),
+            wt_client.add_update_tower(tower_id, &updated_tower_info.net_addr, &receipt),
             Err(SubscriptionError::Expiry)
+        ));
+        assert!(matches!(
+            wt_client.add_update_tower(tower_id, &updated_tower_info.net_addr, &receipt_same_slots),
+            Err(SubscriptionError::Slots)
         ));
         assert!(matches!(
             wt_client.add_update_tower(
                 tower_id,
-                updated_tower_info.net_addr.clone(),
-                &receipt_same_slots
+                &updated_tower_info.net_addr,
+                &receipt_same_expiry
             ),
-            Err(SubscriptionError::Slots)
-        ));
-        assert!(matches!(
-            wt_client.add_update_tower(tower_id, updated_tower_info.net_addr, &receipt_same_expiry),
             Err(SubscriptionError::Expiry)
         ));
     }
@@ -713,7 +713,7 @@ mod tests {
 
         // Add the tower and check it is there
         wt_client
-            .add_update_tower(tower_id, tower_info.net_addr.clone(), &receipt)
+            .add_update_tower(tower_id, &tower_info.net_addr, &receipt)
             .unwrap();
         assert_eq!(
             wt_client.towers.get(&tower_id),
@@ -731,7 +731,7 @@ mod tests {
 
         // Try again but this time with an associated appointment to check that it also gets removed
         wt_client
-            .add_update_tower(tower_id, tower_info.net_addr, &receipt)
+            .add_update_tower(tower_id, &tower_info.net_addr, &receipt)
             .unwrap();
 
         let locator = generate_random_appointment(None).locator;
@@ -779,10 +779,10 @@ mod tests {
             receipt.subscription_expiry(),
         );
         wt_client
-            .add_update_tower(tower1_id, tower_info.net_addr.clone(), &receipt)
+            .add_update_tower(tower1_id, &tower_info.net_addr, &receipt)
             .unwrap();
         wt_client
-            .add_update_tower(tower2_id, tower_info.net_addr, &receipt)
+            .add_update_tower(tower2_id, &tower_info.net_addr, &receipt)
             .unwrap();
 
         let locator = generate_random_appointment(None).locator;


### PR DESCRIPTION
Some `Strings` could be replaced by `&str` and some calls made more explicit.