### PR TITLE
Fix third party logging

### DIFF
--- a/teos/src/cli_config.rs
+++ b/teos/src/cli_config.rs
@@ -54,10 +54,6 @@ pub struct Opt {
     #[structopt(long, default_value = "~/.teos")]
     pub data_dir: String,
 
-    /// Runs teos-cli in debug mode [default: false]
-    #[structopt(long)]
-    pub debug: bool,
-
     /// Command
     #[structopt(subcommand)]
     pub command: Command,
@@ -74,7 +70,6 @@ pub struct Opt {
 pub struct Config {
     pub rpc_bind: String,
     pub rpc_port: u16,
-    pub debug: bool,
 }
 
 impl Config {
@@ -86,8 +81,6 @@ impl Config {
         if options.rpc_port.is_some() {
             self.rpc_port = options.rpc_port.unwrap();
         }
-
-        self.debug |= options.debug;
     }
 }
 
@@ -102,7 +95,6 @@ impl Default for Config {
         Self {
             rpc_bind: "localhost".into(),
             rpc_port: 8814,
-            debug: false,
         }
     }
 }

--- a/teos/src/conf_template.toml
+++ b/teos/src/conf_template.toml
@@ -18,6 +18,7 @@ btc_rpc_port = 8332
 
 # Flags
 debug = false
+deps_debug = false
 overwrite_key = false
 
 # General

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -90,6 +90,10 @@ pub struct Opt {
     #[structopt(long)]
     pub debug: bool,
 
+    /// Runs third party libs in debug mode
+    #[structopt(long)]
+    pub deps_debug: bool,
+
     /// Overwrites the tower secret key. THIS IS IRREVERSIBLE AND WILL CHANGE YOUR TOWER ID
     #[structopt(long)]
     pub overwrite_key: bool,
@@ -133,6 +137,7 @@ pub struct Config {
 
     // Flags
     pub debug: bool,
+    pub deps_debug: bool,
     pub overwrite_key: bool,
 
     // General
@@ -191,6 +196,7 @@ impl Config {
 
         self.tor_support |= options.tor_support;
         self.debug |= options.debug;
+        self.deps_debug |= options.deps_debug;
         self.overwrite_key = options.overwrite_key;
     }
 
@@ -261,6 +267,7 @@ impl Default for Config {
             btc_rpc_port: 0,
 
             debug: false,
+            deps_debug: false,
             overwrite_key: false,
             subscription_slots: 10000,
             subscription_duration: 4320,
@@ -295,6 +302,7 @@ mod tests {
                 data_dir: String::from("~/.teos"),
 
                 debug: false,
+                deps_debug: false,
                 overwrite_key: false,
             }
         }

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -1,4 +1,5 @@
-use simple_logger::init_with_level;
+use log::LevelFilter;
+use simple_logger::SimpleLogger;
 use std::fs;
 use std::io::ErrorKind;
 use std::ops::{Deref, DerefMut};
@@ -83,11 +84,22 @@ async fn main() {
     });
 
     // Set log level
-    if conf.debug {
-        init_with_level(log::Level::Debug).unwrap()
-    } else {
-        init_with_level(log::Level::Info).unwrap()
-    }
+    SimpleLogger::new()
+        .with_level(if conf.deps_debug {
+            LevelFilter::Debug
+        } else {
+            LevelFilter::Warn
+        })
+        .with_module_level(
+            "teos",
+            if conf.debug {
+                LevelFilter::Debug
+            } else {
+                LevelFilter::Info
+            },
+        )
+        .init()
+        .unwrap();
 
     if is_default {
         log::info!("Loading default configuration")


### PR DESCRIPTION
Splits debug logging into two options: `debug` and `deps_debug` so we don't need to log third-party stuff in debug mode if we don't really need to (which is the most usual case).

Also, remove `debug` from `teos-cli` given it was not being used.