### PR TITLE
Updates actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Rust ${{ matrix.toolchain }} toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cln-plugin.yaml
+++ b/.github/workflows/cln-plugin.yaml
@@ -10,8 +10,11 @@ jobs:
   cache-cln:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
       - name: Create CLN cache
         id: cache-cln
         uses: actions/cache@v3
@@ -21,6 +24,8 @@ jobs:
           path: lightning
           key: ${{ runner.os }}-build-${{ env.cache-name }}-v${{ env.cln_version }}
       - name: Compile CLN
+        env: 
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         if: ${{ steps.cache-cln.outputs.cache-hit != 'true' }}
         run: |
           sudo apt-get update && sudo apt-get install gettext
@@ -32,8 +37,11 @@ jobs:
     needs: cache-cln
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
       - name: Install bitcoind
         run: |
           wget https://bitcoincore.org/bin/bitcoin-core-${{ env.bitcoind_version }}/bitcoin-${{ env.bitcoind_version }}-x86_64-linux-gnu.tar.gz

--- a/teos/src/extended_appointment.rs
+++ b/teos/src/extended_appointment.rs
@@ -22,7 +22,7 @@ impl UUID {
     /// Therefore, it provides a hard-to-forge id while reducing the tower lookups and the required data to be stored (no reverse maps).
     pub fn new(locator: Locator, user_id: UserId) -> Self {
         let mut uuid_data = locator.to_vec();
-        uuid_data.extend(&user_id.0.serialize());
+        uuid_data.extend(user_id.0.serialize());
         UUID(ripemd160::Hash::hash(&uuid_data).into_inner())
     }
 


### PR DESCRIPTION
## Motivation
GH seems to have changed the way caches are handled and the old action caches are gone. Our CLN cache does not build anymore with the old actions (things used to work due to the old cache being restored).

Some actions are using deprecated stuff, update them. The only missing thing to be updated is actions-rs/toolchail, but there is no new version of it.

This is already been tracked, but looks like the project is not maintained:

https://github.com/actions-rs/toolchain/issues/219
https://github.com/actions-rs/toolchain/issues/221

If this ends up being an issue, we can manually install rust: https://github.com/actions-rs/toolchain/issues/216#issuecomment-1291613319