### PR TITLE
Fixes tor proxy redirection

### DIFF
--- a/teos/src/api/tor.rs
+++ b/teos/src/api/tor.rs
@@ -35,7 +35,7 @@ async fn store_tor_key(key: &TorSecretKeyV3, path: PathBuf) {
 /// Expose an onion service that re-directs to the public api.
 pub async fn expose_onion_service(
     tor_control_port: u16,
-    api_port: u16,
+    api_endpoint: SocketAddr,
     onion_port: u16,
     path: PathBuf,
     service_ready: Trigger,
@@ -83,11 +83,7 @@ pub async fn expose_onion_service(
             false,
             false,
             None,
-            &mut [(
-                onion_port,
-                format!("127.0.0.1:{}", api_port).parse().unwrap(),
-            )]
-            .iter(),
+            &mut [(onion_port, api_endpoint)].iter(),
         )
         .await
         .map_err(|e| {

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -339,13 +339,12 @@ async fn main() {
     if conf.tor_support {
         log::info!("Starting up Tor hidden service");
         let tor_control_port = conf.tor_control_port;
-        let api_port = conf.api_port;
         let onion_port = conf.onion_hidden_service_port;
 
         tor_task = Some(task::spawn(async move {
             if let Err(e) = tor::expose_onion_service(
                 tor_control_port,
-                api_port,
+                http_api_addr,
                 onion_port,
                 path_network,
                 tor_service_ready,


### PR DESCRIPTION
Traffic routed trough Tor was being redirected to localhost indistinguishably of whether the public http API was being offered there or not. This made the tower unavailable (trough Tor) when it was being offered both in clearnet and Tor.