### PR TITLE
Fixes CLN version to version 0.1.0 until the code can be upgraded

### DIFF
--- a/watchtower-plugin/Cargo.toml
+++ b/watchtower-plugin/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1.5", features = [ "rt-multi-thread", "fs" ] }
 
 # Bitcoin and Lightning
 bitcoin = "0.28.0"
-cln-plugin = "0.1.0"
+cln-plugin = "=0.1.0"
 
 # Local
 teos-common = { path = "../teos-common" }


### PR DESCRIPTION
`cln-plugin` was updated to version `0.1.1` which has breaking changes. Fix out version until `watchtower-plugin` can be patched.

close #147 