### PR TITLE
Adds addresses field to `gettowerinfo`

### DIFF
--- a/teos-common/src/lib.rs
+++ b/teos-common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod constants;
 pub mod cryptography;
 pub mod dbm;
 pub mod errors;
+pub mod net;
 pub mod receipts;
 pub mod ser;
 pub mod test_utils;

--- a/teos-common/src/net.rs
+++ b/teos-common/src/net.rs
@@ -1,0 +1,39 @@
+use std::fmt;
+
+/// Represents all types of teos network addresses
+pub enum AddressType {
+    IpV4 = 0,
+    TorV3 = 1,
+}
+
+impl From<i32> for AddressType {
+    fn from(x: i32) -> Self {
+        match x {
+            0 => AddressType::IpV4,
+            1 => AddressType::TorV3,
+            x => panic!("Unknown address type {}", x),
+        }
+    }
+}
+
+impl std::str::FromStr for AddressType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ipv4" => Ok(AddressType::IpV4),
+            "torv3" => Ok(AddressType::TorV3),
+            _ => Err(format!("Unknown type: {}", s)),
+        }
+    }
+}
+
+impl fmt::Display for AddressType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match self {
+            AddressType::IpV4 => "ipv4",
+            AddressType::TorV3 => "torv3",
+        };
+        write!(f, "{}", s)
+    }
+}

--- a/teos/build.rs
+++ b/teos/build.rs
@@ -12,6 +12,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "GetUserResponse.appointments",
             "#[serde(serialize_with = \"teos_common::ser::serde_vec_bytes::serialize\")]",
         )
+        .field_attribute(
+            "NetworkAddress.address_type",
+            "#[serde(rename = \"type\", with = \"crate::api::serde::serde_address_type\")]",
+        )
         .compile(
             &[
                 "proto/teos/v2/appointment.proto",

--- a/teos/proto/teos/v2/tower_services.proto
+++ b/teos/proto/teos/v2/tower_services.proto
@@ -7,15 +7,26 @@ import "common/teos/v2/appointment.proto";
 import "common/teos/v2/user.proto";
 import "google/protobuf/empty.proto";
 
+message NetworkAddress {
+  // Tower public API endpoint.
+  enum AddressType {
+    IpV4 = 0;
+    TorV3 = 1;
+  }
+  AddressType address_type = 1;
+  string address = 2;
+  uint32 port = 3;
+
+}
 
 message GetTowerInfoResponse {
   // Response with information about the tower.
-
   bytes tower_id = 1;
   uint32 n_registered_users = 2;
   uint32 n_watcher_appointments = 3;
   uint32 n_responder_trackers = 4;
   bool bitcoind_reachable = 5;
+  repeated NetworkAddress addresses = 6;
 }
 
 service PublicTowerServices {

--- a/teos/src/api/internal.rs
+++ b/teos/src/api/internal.rs
@@ -21,6 +21,8 @@ use teos_common::UserId;
 pub struct InternalAPI {
     /// A [Watcher] instance.
     watcher: Arc<Watcher>,
+    /// A list of public API endpoints.
+    addresses: Vec<msgs::NetworkAddress>,
     /// A flag that indicates wether bitcoind is reachable or not.
     bitcoind_reachable: Arc<(Mutex<bool>, Condvar)>,
     /// A signal indicating the tower is shuting down.
@@ -31,14 +33,20 @@ impl InternalAPI {
     /// Creates a new [InternalAPI] instance.
     pub fn new(
         watcher: Arc<Watcher>,
+        addresses: Vec<msgs::NetworkAddress>,
         bitcoind_reachable: Arc<(Mutex<bool>, Condvar)>,
         shutdown_trigger: Trigger,
     ) -> Self {
         Self {
             watcher,
+            addresses,
             bitcoind_reachable,
             shutdown_trigger,
         }
+    }
+
+    pub fn get_addresses(&self) -> &Vec<msgs::NetworkAddress> {
+        &self.addresses
     }
 
     /// Checks whether bitcoind is reachable.
@@ -305,6 +313,7 @@ impl PrivateTowerServices for Arc<InternalAPI> {
     ) -> Result<Response<msgs::GetTowerInfoResponse>, Status> {
         Ok(Response::new(msgs::GetTowerInfoResponse {
             tower_id: self.watcher.tower_id.to_vec(),
+            addresses: self.get_addresses().clone(),
             n_registered_users: self.watcher.get_registered_users_count() as u32,
             n_watcher_appointments: self.watcher.get_appointments_count() as u32,
             n_responder_trackers: self.watcher.get_trackers_count() as u32,

--- a/teos/src/api/mod.rs
+++ b/teos/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub mod http;
 pub mod internal;
+pub mod serde;
 pub mod tor;

--- a/teos/src/api/serde.rs
+++ b/teos/src/api/serde.rs
@@ -1,0 +1,62 @@
+use crate::protos as msgs;
+
+use teos_common::net::AddressType;
+
+impl msgs::NetworkAddress {
+    pub fn from_ipv4(address: String, port: u16) -> Self {
+        Self {
+            address_type: AddressType::IpV4 as i32,
+            address,
+            port: port as u32,
+        }
+    }
+
+    pub fn from_torv3(address: String, port: u16) -> Self {
+        Self {
+            address_type: AddressType::TorV3 as i32,
+            address,
+            port: port as u32,
+        }
+    }
+}
+
+pub mod serde_address_type {
+    use serde::de::{self, Deserializer};
+    use serde::Serializer;
+    use std::str::FromStr;
+
+    use super::AddressType;
+
+    pub fn serialize<S>(status: &i32, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&AddressType::from(*status).to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<i32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StatusVisitor;
+
+        impl<'de> de::Visitor<'de> for StatusVisitor {
+            type Value = i32;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string containing the address type")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let status = AddressType::from_str(v)
+                    .map_err(|_| E::custom("given address type is unknown"))?;
+                Ok(status as i32)
+            }
+        }
+
+        deserializer.deserialize_any(StatusVisitor)
+    }
+}

--- a/teos/src/api/tor.rs
+++ b/teos/src/api/tor.rs
@@ -5,131 +5,150 @@ use std::path::PathBuf;
 
 use tokio::fs;
 use tokio::net::TcpStream;
-use tokio::time::{sleep, Duration};
 use torut::control::UnauthenticatedConn;
 use torut::onion::TorSecretKeyV3;
 use triggered::{Listener, Trigger};
 
-/// Loads a Tor key from disk (if found).
-async fn load_tor_key(path: PathBuf) -> Option<TorSecretKeyV3> {
-    log::info!("Loading Tor secret key from disk");
-    let key = fs::read(path.join("onion_v3_sk"))
-        .await
-        .map_err(|e| log::warn!("Tor secret key cannot be loaded. {}", e))
-        .ok()?;
-    let key: [u8; 64] = key
-        .try_into()
-        .map_err(|_| log::error!("Cannot convert loaded data into Tor secret key"))
-        .ok()?;
-
-    Some(TorSecretKeyV3::from(key))
-}
-
-/// Stores a Tor key to disk.
-async fn store_tor_key(key: &TorSecretKeyV3, path: PathBuf) {
-    if let Err(e) = fs::write(path.join("onion_v3_sk"), key.as_bytes()).await {
-        log::error!("Cannot store Tor secret key. {}", e);
-    }
-}
-
-/// Expose an onion service that re-directs to the public api.
-pub async fn expose_onion_service(
-    tor_control_port: u16,
+pub struct TorAPI {
+    sk: TorSecretKeyV3,
     api_endpoint: SocketAddr,
     onion_port: u16,
-    path: PathBuf,
-    service_ready: Trigger,
-    shutdown_signal_tor: Listener,
-) -> Result<(), Error> {
-    let stream = connect_tor_cp(format!("127.0.0.1:{}", tor_control_port).parse().unwrap())
-        .await
-        .map_err(|e| Error::new(ErrorKind::ConnectionRefused, e))?;
+    tor_control_port: u16,
+}
 
-    let mut unauth_conn = UnauthenticatedConn::new(stream);
+impl TorAPI {
+    pub async fn new(
+        api_endpoint: SocketAddr,
+        onion_port: u16,
+        tor_control_port: u16,
+        path: PathBuf,
+    ) -> Self {
+        let key = if let Some(key) = TorAPI::load_sk(path.clone()).await {
+            key
+        } else {
+            log::info!("Generating fresh Tor secret key");
+            let key = TorSecretKeyV3::generate();
+            TorAPI::store_sk(&key, path).await;
+            key
+        };
 
-    let pre_auth = unauth_conn
-        .load_protocol_info()
-        .await
-        .map_err(|e| Error::new(ErrorKind::ConnectionRefused, e))?;
-
-    let auth_data = pre_auth
-        .make_auth_data()?
-        .expect("failed to make auth data");
-
-    unauth_conn.authenticate(&auth_data).await.map_err(|_| {
-        Error::new(
-            ErrorKind::PermissionDenied,
-            "failed to authenticate with Tor",
-        )
-    })?;
-
-    let mut auth_conn = unauth_conn.into_authenticated().await;
-
-    auth_conn.set_async_event_handler(Some(|_| async move { Ok(()) }));
-
-    let key = if let Some(key) = load_tor_key(path.clone()).await {
-        key
-    } else {
-        log::info!("Generating fresh Tor secret key");
-        let key = TorSecretKeyV3::generate();
-        store_tor_key(&key, path).await;
-        key
-    };
-
-    auth_conn
-        .add_onion_v3(
-            &key,
-            false,
-            false,
-            false,
-            None,
-            &mut [(onion_port, api_endpoint)].iter(),
-        )
-        .await
-        .map_err(|e| {
-            Error::new(
-                ErrorKind::Other,
-                format!("failed to create onion hidden service: {}", e),
-            )
-        })?;
-
-    print_onion_service(key.clone(), onion_port);
-    service_ready.trigger();
-
-    // NOTE: Needed to keep connection with control port & hidden service running, as soon as we leave
-    // this function the control port stream is dropped and the hidden service is killed
-    loop {
-        sleep(Duration::from_secs(1)).await;
-        if shutdown_signal_tor.is_triggered() {
-            break;
+        Self {
+            sk: key,
+            api_endpoint,
+            onion_port,
+            tor_control_port,
         }
     }
 
-    auth_conn
-        .del_onion(
-            &key.public()
-                .get_onion_address()
-                .get_address_without_dot_onion(),
-        )
-        .await
-        .unwrap();
-    Ok(())
-}
+    pub fn get_onion_address(&self) -> String {
+        self.sk.public().get_onion_address().to_string()
+    }
 
-async fn connect_tor_cp(addr: SocketAddr) -> Result<TcpStream, Error> {
-    let sock = TcpStream::connect(addr).await.map_err(|_| {
-        Error::new(
-            ErrorKind::ConnectionRefused,
-            "failed to connect to Tor control port",
-        )
-    })?;
-    Ok(sock)
-}
+    /// Loads a Tor key from disk (if found).
+    async fn load_sk(path: PathBuf) -> Option<TorSecretKeyV3> {
+        log::info!("Loading Tor secret key from disk");
+        let key = fs::read(path.join("onion_v3_sk"))
+            .await
+            .map_err(|e| log::warn!("Tor secret key cannot be loaded. {}", e))
+            .ok()?;
+        let key: [u8; 64] = key
+            .try_into()
+            .map_err(|_| log::error!("Cannot convert loaded data into Tor secret key"))
+            .ok()?;
 
-fn print_onion_service(key: TorSecretKeyV3, onion_port: u16) {
-    let onion_addr = key.public().get_onion_address();
-    let onion = format!("{}:{}", onion_addr, onion_port);
-    log::info!("Onion service: {}", onion);
+        Some(TorSecretKeyV3::from(key))
+    }
+
+    /// Stores a Tor key to disk.
+    async fn store_sk(key: &TorSecretKeyV3, path: PathBuf) {
+        if let Err(e) = fs::write(path.join("onion_v3_sk"), key.as_bytes()).await {
+            log::error!("Cannot store Tor secret key. {}", e);
+        }
+    }
+
+    /// Tries to connect to the Tor control port
+    async fn connect_tor_cp(&self) -> Result<TcpStream, Error> {
+        let sock = TcpStream::connect(format!("127.0.0.1:{}", self.tor_control_port))
+            .await
+            .map_err(|_| {
+                Error::new(
+                    ErrorKind::ConnectionRefused,
+                    "failed to connect to Tor control port",
+                )
+            })?;
+        Ok(sock)
+    }
+
+    /// Expose an onion service that re-directs to the public api.
+    pub async fn expose_onion_service(
+        &self,
+        service_ready: Trigger,
+        shutdown_signal_tor: Listener,
+    ) -> Result<(), Error> {
+        let stream = self
+            .connect_tor_cp()
+            .await
+            .map_err(|e| Error::new(ErrorKind::ConnectionRefused, e))?;
+
+        let mut unauth_conn = UnauthenticatedConn::new(stream);
+
+        let pre_auth = unauth_conn
+            .load_protocol_info()
+            .await
+            .map_err(|e| Error::new(ErrorKind::ConnectionRefused, e))?;
+
+        let auth_data = pre_auth
+            .make_auth_data()?
+            .expect("failed to make auth data");
+
+        unauth_conn.authenticate(&auth_data).await.map_err(|_| {
+            Error::new(
+                ErrorKind::PermissionDenied,
+                "failed to authenticate with Tor",
+            )
+        })?;
+
+        let mut auth_conn = unauth_conn.into_authenticated().await;
+
+        auth_conn.set_async_event_handler(Some(|_| async move { Ok(()) }));
+
+        auth_conn
+            .add_onion_v3(
+                &self.sk,
+                false,
+                false,
+                false,
+                None,
+                &mut [(self.onion_port, self.api_endpoint)].iter(),
+            )
+            .await
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::Other,
+                    format!("failed to create onion hidden service: {}", e),
+                )
+            })?;
+
+        log::info!(
+            "Onion service: {}:{}",
+            self.get_onion_address(),
+            self.onion_port
+        );
+        service_ready.trigger();
+        shutdown_signal_tor.await;
+
+        auth_conn
+            .del_onion(
+                &self
+                    .sk
+                    .public()
+                    .get_onion_address()
+                    .get_address_without_dot_onion(),
+            )
+            .await
+            .unwrap();
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -140,40 +159,48 @@ mod tests {
     use teos_common::test_utils::get_random_user_id;
 
     #[tokio::test]
-    async fn test_store_load_key() {
+    async fn test_store_load_sk() {
         let key = TorSecretKeyV3::generate();
         let tmp_path = TempDir::new(&format!("data_dir_{}", get_random_user_id())).unwrap();
 
-        store_tor_key(&key, tmp_path.path().into()).await;
-        let loaded_key = load_tor_key(tmp_path.path().into()).await;
+        TorAPI::store_sk(&key, tmp_path.path().into()).await;
+        let loaded_key = TorAPI::load_sk(tmp_path.path().into()).await;
 
         assert_eq!(key, loaded_key.unwrap())
     }
 
     #[tokio::test]
-    async fn test_load_key_inexistent() {
+    async fn test_load_sk_inexistent() {
         let tmp_path = TempDir::new(&format!("data_dir_{}", get_random_user_id())).unwrap();
-        let loaded_key = load_tor_key(tmp_path.path().into()).await;
+        let loaded_key = TorAPI::load_sk(tmp_path.path().into()).await;
 
         assert_eq!(loaded_key, None);
     }
 
     #[tokio::test]
-    async fn test_load_key_wrong_format() {
+    async fn test_load_sk_wrong_format() {
         let tmp_path = TempDir::new(&format!("data_dir_{}", get_random_user_id())).unwrap();
         fs::write(tmp_path.path().join("onion_v3_sk"), "random stuff")
             .await
             .unwrap();
-        let loaded_key = load_tor_key(tmp_path.path().into()).await;
+        let loaded_key = TorAPI::load_sk(tmp_path.path().into()).await;
 
         assert_eq!(loaded_key, None);
     }
 
     #[tokio::test]
     async fn test_connect_tor_cp_fail() {
-        let tor_control_port = 9000;
-        let addr = format!("127.0.0.1:{}", tor_control_port).parse().unwrap();
-        match connect_tor_cp(addr).await {
+        let wrong_cp = 9000;
+        let tmp_path = TempDir::new(&format!("data_dir_{}", get_random_user_id())).unwrap();
+        let tor_api = TorAPI::new(
+            "127.0.1.1:9814".parse().unwrap(),
+            9814,
+            wrong_cp,
+            tmp_path.path().into(),
+        )
+        .await;
+
+        match tor_api.connect_tor_cp().await {
             Ok(_) => {}
             Err(e) => {
                 assert_eq!("failed to connect to Tor control port", e.to_string())

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -45,6 +45,7 @@ use crate::carrier::Carrier;
 use crate::dbm::DBM;
 use crate::extended_appointment::{ExtendedAppointment, UUID};
 use crate::gatekeeper::{Gatekeeper, UserInfo};
+use crate::protos as msgs;
 use crate::responder::{ConfirmationStatus, Responder, TransactionTracker};
 use crate::rpc_errors;
 use crate::watcher::{Breach, Watcher};
@@ -496,6 +497,7 @@ pub(crate) async fn create_api_with_config(
     (
         Arc::new(InternalAPI::new(
             Arc::new(watcher),
+            vec![msgs::NetworkAddress::from_ipv4("address".to_string(), 21)],
             bitcoind_reachable,
             shutdown_trigger,
         )),


### PR DESCRIPTION
This PR adds a new field to the `gettowerinfo` RPC call. The field includes data regarding the interfaces where the public API is being offered (i.e. ipv4 and/or tor).

The rationale for this is having the API endpoint information handy without having to check the logs (this is currently most relevant for the onion address).

Fixes https://github.com/talaia-labs/rust-teos/issues/143

cc/ @jochemin