### PR TITLE
Adds a fixed sleep so `TeosD` has time to bootstrap in the `watchtower-plugin` tests

### DIFF
--- a/watchtower-plugin/tests/conftest.py
+++ b/watchtower-plugin/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import json
+import time
 import pytest
 import logging
 import subprocess
@@ -86,6 +87,7 @@ class TeosD(TailableProc):
         # made me think that re-initializing it may work (TailableProc.__init(...)) given that re-sets the logs and the
         # offset, but this also fails some times. I don't think it is work wasting much more time here atm.
         # self.wait_for_log("Tower ready", timeout=TIMEOUT)
+        time.sleep(2)
         logging.info("TeosD started")
 
     def stop(self):


### PR DESCRIPTION
This is adding a fixed sleep to `watchtower-plugin::tests` given they may still fail due to `TeosD` not having enough time to bootstrap after the log check was temporarily removed. 

Rationale: https://github.com/talaia-labs/rust-teos/issues/156#issuecomment-1326555685

Notice this is temporary and should be removed once #156 is addressed.