### PR TITLE
Improves tor flag logic in watchtower-plugin

### DIFF
--- a/teos-common/src/net.rs
+++ b/teos-common/src/net.rs
@@ -1,6 +1,8 @@
+use serde::Serialize;
 use std::fmt;
 
 /// Represents all types of teos network addresses
+#[derive(Clone, Serialize, Debug, PartialEq, Eq)]
 pub enum AddressType {
     IpV4 = 0,
     TorV3 = 1,
@@ -35,5 +37,78 @@ impl fmt::Display for AddressType {
             AddressType::TorV3 => "torv3",
         };
         write!(f, "{}", s)
+    }
+}
+
+impl AddressType {
+    pub fn get_type(net_addr: &str) -> AddressType {
+        if net_addr.contains(".onion:") {
+            AddressType::TorV3
+        } else {
+            AddressType::IpV4
+        }
+    }
+
+    pub fn is_tor(&self) -> bool {
+        self == &AddressType::TorV3
+    }
+
+    pub fn is_clearnet(&self) -> bool {
+        self == &AddressType::IpV4
+    }
+}
+
+#[derive(Clone, Serialize, Debug, PartialEq, Eq)]
+pub struct NetAddr {
+    net_addr: String,
+    #[serde(skip)]
+    addr_type: AddressType,
+}
+
+impl NetAddr {
+    pub fn new(net_addr: String) -> Self {
+        NetAddr {
+            addr_type: AddressType::get_type(&net_addr),
+            net_addr,
+        }
+    }
+
+    pub fn net_addr(&self) -> &str {
+        &self.net_addr
+    }
+
+    pub fn addr_type(&self) -> &AddressType {
+        &self.addr_type
+    }
+
+    pub fn is_onion(&self) -> bool {
+        self.addr_type().is_tor()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    pub const TORV3_ADDR: &str =
+        "recnedb7xfhzjdrcgxongzli3a6qyrv5jwgowoho3v5g3rwk7kkglrid.onion:9814";
+    pub const IPV4_ADDR: &str = "teos.talaia.watch:9814";
+
+    #[test]
+    fn test_get_type() {
+        assert_eq!(AddressType::get_type(TORV3_ADDR), AddressType::TorV3);
+        assert_eq!(AddressType::get_type(IPV4_ADDR), AddressType::IpV4);
+    }
+
+    #[test]
+    fn test_is_tor() {
+        assert!(NetAddr::new(TORV3_ADDR.to_owned()).addr_type.is_tor());
+        assert!(!NetAddr::new(IPV4_ADDR.to_owned()).addr_type.is_tor());
+    }
+
+    #[test]
+    fn test_is_clearnet() {
+        assert!(!NetAddr::new(TORV3_ADDR.to_owned()).addr_type.is_clearnet());
+        assert!(NetAddr::new(IPV4_ADDR.to_owned()).addr_type.is_clearnet());
     }
 }

--- a/watchtower-plugin/src/lib.rs
+++ b/watchtower-plugin/src/lib.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use serde::Serialize;
 
 use teos_common::appointment::{Appointment, Locator};
+use teos_common::net::NetAddr;
 use teos_common::receipts::AppointmentReceipt;
 use teos_common::TowerId;
 
@@ -101,7 +102,8 @@ impl TowerStatus {
 /// Summarized data associated with a given tower.
 #[derive(Clone, Serialize, Debug, PartialEq, Eq)]
 pub struct TowerSummary {
-    pub net_addr: String,
+    #[serde(flatten)]
+    pub net_addr: NetAddr,
     pub available_slots: u32,
     subscription_start: u32,
     pub subscription_expiry: u32,
@@ -121,7 +123,7 @@ impl TowerSummary {
         subscription_expiry: u32,
     ) -> Self {
         Self {
-            net_addr,
+            net_addr: NetAddr::new(net_addr),
             available_slots,
             subscription_start,
             subscription_expiry,
@@ -141,7 +143,7 @@ impl TowerSummary {
         invalid_appointments: HashSet<Locator>,
     ) -> Self {
         Self {
-            net_addr,
+            net_addr: NetAddr::new(net_addr),
             available_slots,
             subscription_start,
             subscription_expiry,
@@ -165,7 +167,7 @@ impl TowerSummary {
         subscription_start: u32,
         subscription_expiry: u32,
     ) {
-        self.net_addr = net_addr;
+        self.net_addr = NetAddr::new(net_addr);
         self.available_slots = available_slots;
         self.subscription_start = subscription_start;
         self.subscription_expiry = subscription_expiry;
@@ -364,6 +366,12 @@ mod tests {
 
         use teos_common::test_utils::generate_random_appointment;
 
+        impl TowerSummary {
+            pub fn set_net_addr(&mut self, net_addr: String) {
+                self.net_addr = NetAddr::new(net_addr);
+            }
+        }
+
         #[test]
         fn test_new() {
             let net_addr: String = "addr".to_owned();
@@ -377,7 +385,7 @@ mod tests {
             assert_eq!(
                 tower_summary,
                 TowerSummary {
-                    net_addr,
+                    net_addr: NetAddr::new(net_addr),
                     available_slots: AVAILABLE_SLOTS,
                     subscription_start: SUBSCRIPTION_START,
                     subscription_expiry: SUBSCRIPTION_EXPIRY,
@@ -408,7 +416,7 @@ mod tests {
             assert_eq!(
                 tower_summary,
                 TowerSummary {
-                    net_addr,
+                    net_addr: NetAddr::new(net_addr),
                     available_slots: AVAILABLE_SLOTS,
                     subscription_start: SUBSCRIPTION_START,
                     subscription_expiry: SUBSCRIPTION_EXPIRY,

--- a/watchtower-plugin/src/net/mod.rs
+++ b/watchtower-plugin/src/net/mod.rs
@@ -1,1 +1,25 @@
+use cln_plugin::messages;
+use serde::Deserialize;
 pub mod http;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ProxyInfo {
+    #[serde(flatten)]
+    /// The proxy data
+    inner: messages::ProxyInfo,
+    /// Whether to only send data though Tor or not
+    pub always_use: bool,
+}
+
+impl ProxyInfo {
+    pub fn new(proxy: messages::ProxyInfo, always_use: bool) -> Self {
+        Self {
+            inner: proxy,
+            always_use,
+        }
+    }
+
+    pub fn get_socks_addr(&self) -> String {
+        format!("socks5h://{}:{}", self.inner.address, self.inner.port)
+    }
+}

--- a/watchtower-plugin/tests/conftest.py
+++ b/watchtower-plugin/tests/conftest.py
@@ -27,7 +27,9 @@ class TeosCLI:
     def _call(self, method_name, *args):
         try:
             r = subprocess.run(
-                ["teos-cli", f"--datadir={self.datadir}/teos", method_name, *args], capture_output=True, text=True
+                ["teos-cli", f"--datadir={self.datadir}/teos", method_name, *args],
+                capture_output=True,
+                text=True,
             )
             if r.returncode != 0:
                 result = ValueError(f"Unknown method {method_name}")

--- a/watchtower-plugin/tests/test.py
+++ b/watchtower-plugin/tests/test.py
@@ -1,4 +1,5 @@
 import pytest
+from pyln.client import RpcError
 from conftest import WT_PLUGIN
 
 
@@ -69,7 +70,10 @@ def test_watchtower(node_factory, bitcoind, teosd):
             assert l2.rpc.getappointment(tower_id, locator)["status"] == "dispute_responded"
         else:
             # Once the channel gets irrevocably resolved the tower will forget about it
-            assert l2.rpc.getappointment(tower_id, locator) == {"error": "Appointment not found", "error_code": 36}
+            assert l2.rpc.getappointment(tower_id, locator) == {
+                "error": "Appointment not found",
+                "error_code": 36,
+            }
 
     # Make sure the penalty outputs are in l2's wallet
     fund_txids = [o["txid"] for o in l2.rpc.listfunds()["outputs"]]
@@ -114,7 +118,16 @@ def test_unreachable_watchtower(node_factory, bitcoind, teosd):
 def test_auto_retry_watchtower(node_factory, bitcoind, teosd):
     # The plugin is set to give up on retrying straight-away so we can test this fast.
     l1, l2 = node_factory.line_graph(
-        2, opts=[{}, {"plugin": WT_PLUGIN, "allow_broken_log": True, "watchtower-max-retry-time": 1, "watchtower-auto-retry-delay": 1}]
+        2,
+        opts=[
+            {},
+            {
+                "plugin": WT_PLUGIN,
+                "allow_broken_log": True,
+                "watchtower-max-retry-time": 1,
+                "watchtower-auto-retry-delay": 1,
+            },
+        ],
     )
 
     # We need to register l2 with the tower
@@ -143,7 +156,15 @@ def test_auto_retry_watchtower(node_factory, bitcoind, teosd):
 def test_manually_retry_watchtower(node_factory, bitcoind, teosd):
     # The plugin is set to give up on retrying straight-away so we can test this fast.
     l1, l2 = node_factory.line_graph(
-        2, opts=[{}, {"plugin": WT_PLUGIN, "allow_broken_log": True, "watchtower-max-retry-time": 0}]
+        2,
+        opts=[
+            {},
+            {
+                "plugin": WT_PLUGIN,
+                "allow_broken_log": True,
+                "watchtower-max-retry-time": 0,
+            },
+        ],
     )
 
     # We need to register l2 with the tower


### PR DESCRIPTION
## Changes
The `watchtower-plugin` was specifying a custom tor flag to signal whether Tor may be used by the client. This was due to `cln-plugin (v0.1.1-)` not allowing plugins to access the CoreLN configuration options and, therefore, our plugin was unable to fetch the `proxy` / `always-use-proxy` options.

This fetches the aforementioned options and revamps the logic to comply with the `always-use-proxy` requirements, that is, if the flag is set all communications must be performed using Tor. Also, it replaces some of the currently used `String`s for more meaningful types to store network data (such as `AddressType`, `NetAddress`, or `ProxyInfo`).

This drops our custom `watchtower-proxy` config option