### PR TITLE
Implements auto-register for the watchtower-client

### DIFF
--- a/teos-common/src/receipts.rs
+++ b/teos-common/src/receipts.rs
@@ -25,7 +25,7 @@ pub struct RegistrationReceipt {
     available_slots: u32,
     subscription_start: u32,
     subscription_expiry: u32,
-    #[serde(skip)]
+    #[serde(rename = "subscription_signature")]
     signature: Option<String>,
 }
 

--- a/watchtower-plugin/src/dbm.rs
+++ b/watchtower-plugin/src/dbm.rs
@@ -289,6 +289,9 @@ impl DBM {
             if self.exists_misbehaving_proof(tower_id) {
                 tower.status = TowerStatus::Misbehaving;
             } else if !tower.pending_appointments.is_empty() {
+                // TODO: We could set the status to SubscriptionError here if we checked the state of the subscription
+                // (using available_slots and expiry). This will be possible once we implement cln rpc queries (which are
+                // already viable since cln-plugin = "0.1.1").
                 tower.status = TowerStatus::TemporaryUnreachable;
             }
 

--- a/watchtower-plugin/src/lib.rs
+++ b/watchtower-plugin/src/lib.rs
@@ -90,6 +90,11 @@ impl TowerStatus {
     pub fn is_subscription_error(&self) -> bool {
         *self == TowerStatus::SubscriptionError
     }
+
+    /// Whether the tower can be manually retried
+    pub fn is_retryable(&self) -> bool {
+        self.is_unreachable() || self.is_subscription_error()
+    }
 }
 
 /// Summarized data associated with a given tower.
@@ -268,11 +273,12 @@ mod tests {
 
     mod tower_status {
         use super::*;
+        use TowerStatus::*;
 
         #[test]
         fn test_is_reachable() {
             for status in STATUSES {
-                if status == TowerStatus::Reachable {
+                if status == Reachable {
                     assert!(status.is_reachable())
                 } else {
                     assert!(!status.is_reachable());
@@ -281,9 +287,31 @@ mod tests {
         }
 
         #[test]
+        fn test_is_temporary_reachable() {
+            for status in STATUSES {
+                if status == TemporaryUnreachable {
+                    assert!(status.is_temporary_unreachable())
+                } else {
+                    assert!(!status.is_temporary_unreachable());
+                }
+            }
+        }
+
+        #[test]
+        fn test_is_unreachable() {
+            for status in STATUSES {
+                if status == Unreachable {
+                    assert!(status.is_unreachable())
+                } else {
+                    assert!(!status.is_unreachable());
+                }
+            }
+        }
+
+        #[test]
         fn test_is_misbehaving() {
             for status in STATUSES {
-                if status == TowerStatus::Misbehaving {
+                if status == Misbehaving {
                     assert!(status.is_misbehaving())
                 } else {
                     assert!(!status.is_misbehaving());
@@ -294,10 +322,21 @@ mod tests {
         #[test]
         fn test_is_subscription_error() {
             for status in STATUSES {
-                if status == TowerStatus::SubscriptionError {
+                if status == SubscriptionError {
                     assert!(status.is_subscription_error())
                 } else {
                     assert!(!status.is_subscription_error());
+                }
+            }
+        }
+
+        #[test]
+        fn test_is_retryable() {
+            for status in STATUSES {
+                if status == Unreachable || status == SubscriptionError {
+                    assert!(status.is_retryable())
+                } else {
+                    assert!(!status.is_retryable());
                 }
             }
         }

--- a/watchtower-plugin/src/retrier.rs
+++ b/watchtower-plugin/src/retrier.rs
@@ -188,10 +188,8 @@ impl Retrier {
         {
             let mut state = self.wt_client.lock().unwrap();
             if !state
-                .towers
-                .get(&self.tower_id)
+                .get_tower_status(&self.tower_id)
                 .unwrap()
-                .status
                 .is_subscription_error()
             {
                 state.set_tower_status(self.tower_id, crate::TowerStatus::TemporaryUnreachable);
@@ -374,8 +372,8 @@ impl Retrier {
     pub fn set_tower_status_if_failed(&self) {
         if *self.status.lock().unwrap() == RetrierStatus::Failed {
             let mut state = self.wt_client.lock().unwrap();
-            if let Some(tower) = state.towers.get(&self.tower_id) {
-                if tower.status.is_temporary_unreachable() {
+            if let Some(status) = state.get_tower_status(&self.tower_id) {
+                if status.is_temporary_unreachable() {
                     log::warn!("Setting {} as unreachable", self.tower_id);
                     state.set_tower_status(self.tower_id, crate::TowerStatus::Unreachable);
                 }
@@ -478,10 +476,8 @@ mod tests {
             wt_client
                 .lock()
                 .unwrap()
-                .towers
-                .get(&tower_id)
-                .unwrap()
-                .status,
+                .get_tower_status(&tower_id)
+                .unwrap(),
             TowerStatus::Reachable
         );
         assert!(!wt_client
@@ -539,10 +535,8 @@ mod tests {
         assert!(wt_client
             .lock()
             .unwrap()
-            .towers
-            .get(&tower_id)
+            .get_tower_status(&tower_id)
             .unwrap()
-            .status
             .is_temporary_unreachable());
 
         // Wait until the task gives up and check again
@@ -550,10 +544,8 @@ mod tests {
         assert!(wt_client
             .lock()
             .unwrap()
-            .towers
-            .get(&tower_id)
+            .get_tower_status(&tower_id)
             .unwrap()
-            .status
             .is_unreachable());
 
         task.abort();
@@ -611,10 +603,8 @@ mod tests {
             wt_client
                 .lock()
                 .unwrap()
-                .towers
-                .get(&tower_id)
-                .unwrap()
-                .status,
+                .get_tower_status(&tower_id)
+                .unwrap(),
             TowerStatus::Reachable
         );
         assert!(!wt_client
@@ -694,10 +684,8 @@ mod tests {
         assert!(wt_client
             .lock()
             .unwrap()
-            .towers
-            .get(&tower_id)
+            .get_tower_status(&tower_id)
             .unwrap()
-            .status
             .is_misbehaving());
         api_mock.assert();
 

--- a/watchtower-plugin/src/retrier.rs
+++ b/watchtower-plugin/src/retrier.rs
@@ -11,7 +11,7 @@ use teos_common::cryptography;
 use teos_common::errors;
 use teos_common::UserId as TowerId;
 
-use crate::net::http::{add_appointment, AddAppointmentError};
+use crate::net::http::{self, AddAppointmentError};
 use crate::wt_client::WTClient;
 
 pub struct RetryManager {
@@ -134,7 +134,7 @@ pub enum RetrierStatus {
     /// Retrier is currently retrying the tower. If the retrier receives new appointments, it will
     /// **try** to send them along (but it might not send them).
     ///
-    /// If a retrier status is `Running`, then its associated tower is temporary unreachable.
+    /// If a retrier status is `Running`, then its associated tower is either temporary unreachable or subscription error.
     Running,
     /// Retrier failed retrying the tower. Should not be re-started.
     ///
@@ -181,12 +181,23 @@ impl Retrier {
         // We shouldn't be retrying failed and running retriers.
         debug_assert_eq!(*self.status.lock().unwrap(), RetrierStatus::Stopped);
 
-        // Set the tower as temporary unreachable and the retrier status to running.
-        self.wt_client
-            .lock()
-            .unwrap()
-            .set_tower_status(self.tower_id, crate::TowerStatus::TemporaryUnreachable);
-        self.set_status(RetrierStatus::Running);
+        // When manually retrying the tower may be in either SubscriptionError or Unreachable state.
+        // Flag this as TemporaryUnreachable only if there is no SubscriptionError.
+        // Rationale: if there is a subscription error that needs to be handled first, otherwise we'll
+        //            waste a retry cycle with a request that will always fail.
+        {
+            let mut state = self.wt_client.lock().unwrap();
+            if !state
+                .towers
+                .get(&self.tower_id)
+                .unwrap()
+                .status
+                .is_subscription_error()
+            {
+                state.set_tower_status(self.tower_id, crate::TowerStatus::TemporaryUnreachable);
+            }
+            self.set_status(RetrierStatus::Running);
+        }
 
         tokio::spawn(async move {
             let r = retry_notify(
@@ -229,21 +240,47 @@ impl Retrier {
 
     async fn run(&self) -> Result<(), Error<&'static str>> {
         // Create a new scope so we can get all the data only locking the WTClient once.
-        let (tower_id, net_addr, user_sk, proxy) = {
+        let (tower_id, status, net_addr, user_id, user_sk, proxy) = {
             let wt_client = self.wt_client.lock().unwrap();
             if wt_client.towers.get(&self.tower_id).is_none() {
                 return Err(Error::permanent("Tower was abandoned. Skipping retry"));
             }
 
-            let net_addr = wt_client
-                .towers
-                .get(&self.tower_id)
-                .unwrap()
-                .net_addr
-                .clone();
-            let user_sk = wt_client.user_sk;
-            (self.tower_id, net_addr, user_sk, wt_client.proxy.clone())
+            let tower = wt_client.towers.get(&self.tower_id).unwrap();
+            (
+                self.tower_id,
+                tower.status,
+                tower.net_addr.clone(),
+                wt_client.user_id,
+                wt_client.user_sk,
+                wt_client.proxy.clone(),
+            )
         };
+
+        // If the tower state is subscription_error we need to re-register first. If we cannot, then the retry is aborted.
+        if status.is_subscription_error() {
+            let receipt = http::register(tower_id, user_id, &net_addr, proxy.clone())
+                .await
+                .map_err(|e| {
+                    log::debug!("Cannot renew registration with tower. Error: {:?}", e);
+                    Error::permanent("Cannot renew registration with tower")
+                })?;
+            if !receipt.verify(&tower_id) {
+                return Err(Error::permanent(
+                        "Registration receipt contains bad signature. Are you using the right tower_id?"
+                    ));
+            }
+            self.wt_client
+            .lock()
+            .unwrap()
+            .add_update_tower(tower_id, &net_addr, &receipt).map_err(|e| {
+                if e.is_expiry() {
+                    Error::permanent("Registration receipt contains a subscription expiry that is not higher than the one we are currently registered for")
+                } else {
+                    Error::permanent("Registration receipt does not contain more slots than the ones we are currently registered for")
+                }
+            })?;
+        }
 
         while self.has_pending_appointments() {
             let locators = self.pending_appointments.lock().unwrap().clone();
@@ -256,7 +293,7 @@ impl Retrier {
                     .load_appointment(locator)
                     .unwrap();
 
-                match add_appointment(
+                match http::add_appointment(
                     tower_id,
                     &net_addr,
                     proxy.clone(),
@@ -295,7 +332,7 @@ impl Retrier {
                                         tower_id,
                                         crate::TowerStatus::SubscriptionError,
                                     );
-                                    return Err(Error::permanent("Subscription error"));
+                                    return Err(Error::transient("Subscription error"));
                                 }
                                 _ => {
                                     log::warn!(
@@ -359,9 +396,10 @@ mod tests {
     use tokio::sync::mpsc::unbounded_channel;
 
     use teos_common::errors;
-    use teos_common::receipts::AppointmentReceipt;
+    use teos_common::receipts::{AppointmentReceipt, RegistrationReceipt};
     use teos_common::test_utils::{
         generate_random_appointment, get_random_registration_receipt, get_random_user_id,
+        get_registration_receipt_from_previous,
     };
 
     use crate::net::http::ApiError;
@@ -706,6 +744,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_manage_retry_subscription_error() {
+        let tmp_path = TempDir::new(&format!("watchtower_{}", get_random_user_id())).unwrap();
+        let (tx, rx) = unbounded_channel();
+        let wt_client = Arc::new(Mutex::new(
+            WTClient::new(tmp_path.path().to_path_buf(), tx.clone()).await,
+        ));
+        let server = MockServer::start();
+
+        // Add a tower with pending appointments
+        let (tower_sk, tower_pk) = cryptography::get_random_keypair();
+        let tower_id = TowerId(tower_pk);
+        let mut registration_receipt =
+            RegistrationReceipt::new(wt_client.lock().unwrap().user_id, 21, 42, 420);
+        registration_receipt.sign(&tower_sk);
+        wt_client
+            .lock()
+            .unwrap()
+            .add_update_tower(tower_id, &server.base_url(), &registration_receipt)
+            .unwrap();
+
+        // Add appointment to pending
+        let appointment = generate_random_appointment(None);
+        wt_client
+            .lock()
+            .unwrap()
+            .add_pending_appointment(tower_id, &appointment);
+
+        // Mock the add_appointment response (this is right, so after the re-registration the appointments are accepted)
+        let mut add_appointment_receipt = AppointmentReceipt::new(
+            cryptography::sign(&appointment.to_vec(), &wt_client.lock().unwrap().user_sk).unwrap(),
+            42,
+        );
+        add_appointment_receipt.sign(&tower_sk);
+        let add_appointment_response =
+            get_dummy_add_appointment_response(appointment.locator, &add_appointment_receipt);
+        let add_appointment_mock = server.mock(|when, then| {
+            when.method(POST).path("/add_appointment");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!(add_appointment_response));
+        });
+
+        // Mock the re-registration
+        let mut re_registration_receipt =
+            get_registration_receipt_from_previous(&registration_receipt);
+        re_registration_receipt.sign(&tower_sk);
+        let register_mock = server.mock(|when, then| {
+            when.method(POST).path("/register");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!(re_registration_receipt));
+        });
+
+        // Set the status as SubscriptionError so we simulate the retrier faced this in a previous round
+        wt_client
+            .lock()
+            .unwrap()
+            .set_tower_status(tower_id, TowerStatus::SubscriptionError);
+
+        // Start the task and send the tower to the channel for retry
+        let wt_client_clone = wt_client.clone();
+        let task = tokio::spawn(async move {
+            RetryManager::new(wt_client_clone, rx, MAX_ELAPSED_TIME, MAX_INTERVAL_TIME)
+                .manage_retry()
+                .await
+        });
+        tx.send((tower_id, appointment.locator)).unwrap();
+
+        // Wait for the elapsed time and check how the tower status changed
+        tokio::time::sleep(Duration::from_secs(MAX_ELAPSED_TIME as u64)).await;
+        let state = wt_client.lock().unwrap();
+        let tower = state.towers.get(&tower_id).unwrap();
+        assert!(tower.status.is_reachable());
+        assert!(tower.pending_appointments.is_empty());
+
+        register_mock.assert();
+        add_appointment_mock.assert();
+        task.abort();
+    }
+
+    #[tokio::test]
     async fn test_retry_tower() {
         let (tower_sk, tower_pk) = cryptography::get_random_keypair();
         let tower_id = TowerId(tower_pk);
@@ -892,7 +1011,7 @@ mod tests {
         let retrier = Retrier::new(wt_client, tower_id, appointment.locator);
         let r = retrier.run().await;
 
-        assert_eq!(r, Err(Error::permanent("Subscription error")));
+        assert_eq!(r, Err(Error::transient("Subscription error")));
         api_mock.assert();
     }
 


### PR DESCRIPTION
## Description 

The current version of the `watchtower-plugin` does not auto-renew subscriptions once they expire or get out of appointment slots. This may be annoying and some users may even be unaware that the data is not being back-up anymore due to the subscription needing a renewal. 

This PR fixes this. The approach for the fix is to use the `Retirer` for it given the logic for unreachable towers and towers with a subscription issue was pretty similar. The way this works from now on is the following:

If an appointment is sent to the tower and there is a subscription error, the data is added to pending, the tower is flagged as `subscription_error` and the `Retrier` is notified (so far nothing changed). The `Retirer` will now try to renew the subscription if the state of the tower is `SubscriptionError` before sending any further data though. On failure, the behavior will be the same as before, just giving up, however, on success the pending data will be sent to the tower.

Notice that, from now on, if the `Retrier` gets a subscription error from the tower it won't give up until a re-register has been attempted, therefore this also covers subscription issues faced while retrying pending data. 

Notice there is one case in which the `Retrier` will need an additional cycle to fix a subscription issue and that is if the tower is stopped in such a state. This is due to the tower state not being stored in the database but deduced based on what data is loaded from it on bootstrap. In the case of some pending appointments being found, the tower is flagged as `TemporaryUnreachable` and retried straightaway. This means that, under these conditions, the `Retrier` will:

- Assume the tower is `TempoaryUnreachable` when it is really `SubscriptionError`
- Attempt to send pending data to the tower
- Receive a `SubscriptionError` from the tower
- Backoff (wait for the next retry cycle)
- Try to re-register
    - On success: Try to send the pending data again
    - On failure: Give up 

## Bug fixes
This PR is also fixing a client-side bug related to re-registering. The client was checking that, on re-register, the **available slot count** assigned to the new subscription was higher than **the total count** from the last subscription instead of the **remaining count**.