### PR TITLE
Avoids setting the state of unregistered towers

### DIFF
--- a/watchtower-plugin/src/main.rs
+++ b/watchtower-plugin/src/main.rs
@@ -96,14 +96,13 @@ async fn register(
         )
     })
     .map_err(|e| {
-        if e.is_connection() {
-            plugin
-                .state()
-                .lock()
-                .unwrap()
-                .set_tower_status(tower_id, TowerStatus::TemporaryUnreachable);
+        let mut state = plugin.state().lock().unwrap();
+        if e.is_connection() && state.towers.contains_key(&tower_id) {
+            state.set_tower_status(tower_id, TowerStatus::TemporaryUnreachable);
         }
-        to_cln_error(e)
+        let e = to_cln_error(e);
+        log::info!("{}", e);
+        e
     })?;
 
     if !receipt.verify(&tower_id) {


### PR DESCRIPTION
On failed fresh register the client was trying to set the tower status of an unknown tower. This was generating a `**BORKEN**` log in `lightningd`'s logs.

Adds an additional check for register to prevent this.