### PR TITLE
Adds auto-retry logic to watchtower-plugin

### DIFF
--- a/teos/src/api/http.rs
+++ b/teos/src/api/http.rs
@@ -219,7 +219,7 @@ async fn get_subscription_info(
 
 fn router(
     grpc_conn: PublicTowerServicesClient<Channel>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     let register = warp::post()
         .and(warp::path("register"))
         .and(warp::body::content_length_limit(REGISTER_BODY_LEN).and(warp::body::json()))

--- a/teos/src/api/internal.rs
+++ b/teos/src/api/internal.rs
@@ -351,11 +351,7 @@ impl PrivateTowerServices for Arc<InternalAPI> {
             Some(info) => Ok(Response::new(msgs::GetUserResponse {
                 available_slots: info.available_slots,
                 subscription_expiry: info.subscription_expiry,
-                appointments: info
-                    .appointments
-                    .iter()
-                    .map(|(uuid, _)| uuid.to_vec())
-                    .collect(),
+                appointments: info.appointments.keys().map(|uuid| uuid.to_vec()).collect(),
             })),
             None => Err(Status::new(Code::NotFound, "User not found")),
         }

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -17,7 +17,7 @@ pub fn data_dir_absolute_path(data_dir: String) -> PathBuf {
 }
 
 pub fn from_file<T: Default + serde::de::DeserializeOwned>(path: PathBuf) -> T {
-    match std::fs::read(&path) {
+    match std::fs::read(path) {
         Ok(file_content) => toml::from_slice::<T>(&file_content).map_or_else(
             |e| {
                 eprintln!("Couldn't parse config file: {}", e);

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -1663,7 +1663,7 @@ mod tests {
             watcher.last_known_block_height.load(Ordering::Relaxed),
             chain.get_block_count()
         );
-        watcher.block_connected(&chain.generate(None), chain.get_block_count() as u32);
+        watcher.block_connected(&chain.generate(None), chain.get_block_count());
         assert_eq!(
             watcher.last_known_block_height.load(Ordering::Relaxed),
             chain.get_block_count()

--- a/watchtower-plugin/src/lib.rs
+++ b/watchtower-plugin/src/lib.rs
@@ -155,6 +155,20 @@ impl TowerSummary {
         self.status = status;
         self
     }
+
+    /// Updates the main information about the summary while preserving the appointment maps.
+    pub fn udpate(
+        &mut self,
+        net_addr: String,
+        available_slots: u32,
+        subscription_start: u32,
+        subscription_expiry: u32,
+    ) {
+        self.net_addr = net_addr;
+        self.available_slots = available_slots;
+        self.subscription_start = subscription_start;
+        self.subscription_expiry = subscription_expiry;
+    }
 }
 
 impl From<TowerInfo> for TowerSummary {

--- a/watchtower-plugin/src/wt_client.rs
+++ b/watchtower-plugin/src/wt_client.rs
@@ -150,15 +150,25 @@ impl WTClient {
         self.dbm
             .store_tower_record(tower_id, tower_net_addr, receipt)
             .unwrap();
-        self.towers.insert(
-            tower_id,
-            TowerSummary::new(
+
+        if let Some(summary) = self.towers.get_mut(&tower_id) {
+            summary.udpate(
                 tower_net_addr.to_owned(),
                 receipt.available_slots(),
                 receipt.subscription_start(),
                 receipt.subscription_expiry(),
-            ),
-        );
+            );
+        } else {
+            self.towers.insert(
+                tower_id,
+                TowerSummary::new(
+                    tower_net_addr.to_owned(),
+                    receipt.available_slots(),
+                    receipt.subscription_start(),
+                    receipt.subscription_expiry(),
+                ),
+            );
+        };
 
         Ok(())
     }


### PR DESCRIPTION
## Current State

The current version of the `watchtower-plugin` for CLN will try to re-send data to towers that are not reachable for various reasons using an exponential backoff strategy. However, once the strategy is given up on, the tower will be flagged as unreachable and not further retried (unless the user manually triggers it through the `retrytower` rpc).

## Improvements
This PR adds auto-retry logic, so once a specific unreachable tower is given up on, the retrier is not removed but remains idle and it's launched again after a specific delay (controlled by the `watchtower-auto-retry-delay`). From this point on, retriers will only be removed from the `RetryManager` is they fail due to a permanent error, but not due to a transient one (in which case they will be auto-retried).

In order to achieve this, the retriers now return more meaningful errors (instead of strings) that are used to distinguish why it had to give up retrying, if so.

The way data is shared between the `WTClient` and the `RetryManager` has also been updated in order to achieve this. Beforehand, data were sent one by one in (tower_id, locator) tuples, now, it is sent in (tower_id, RevocationData) tuples, in order to distinguish between retries/bootstraps and sending data because of a channel update.

## Bug fixes
This also fixes a bug related to re-registering, where data regarding pending and invalid appointments was being swept from memory after re-registering.

