### PR TITLE
Simplifies the cln plugin option parsing

### DIFF
--- a/watchtower-plugin/src/constants.rs
+++ b/watchtower-plugin/src/constants.rs
@@ -1,0 +1,52 @@
+// Collection of ENV variable names and values
+pub const TOWERS_DATA_DIR: &str = "TOWERS_DATA_DIR";
+pub const DEFAULT_TOWERS_DATA_DIR: &str = ".watchtower";
+
+/// Collections of plugin option names, default values and descriptions
+
+pub const WT_PORT: &str = "watchtower-port";
+pub const DEFAULT_WT_PORT: i64 = 9814;
+pub const WT_PORT_DESC: &str = "tower API port";
+pub const WT_MAX_RETRY_TIME: &str = "watchtower-max-retry-time";
+pub const DEFAULT_WT_MAX_RETRY_TIME: i64 = 900;
+pub const WT_MAX_RETRY_TIME_DESC: &str = "the time (in seconds) after when a retrier will give up trying to send data to a temporary unreachable tower";
+pub const WT_PROXY: &str = "watchtower-proxy";
+pub const WT_PROXY_DESC: &str = "Socks v5 proxy IP address and port for the watchtower client";
+pub const WT_AUTO_RETRY_DELAY: &str = "watchtower-auto-retry-delay";
+pub const DEFAULT_WT_AUTO_RETRY_DELAY: i64 = 86400;
+pub const WT_AUTO_RETRY_DELAY_DESC: &str = "the time (in seconds) that a retrier will wait before auto-retrying a failed tower. Defaults to once a day";
+pub const DEV_WT_MAX_RETRY_INTERVAL: &str = "dev-watchtower-max-retry-interval";
+pub const DEFAULT_DEV_WT_MAX_RETRY_INTERVAL: i64 = 60;
+pub const DEV_WT_MAX_RETRY_INTERVAL_DESC: &str =
+    "the maximum time (in seconds) for a retrier wait interval";
+
+/// Collections of rpc method names and descriptions
+
+pub const RPC_REGISTER_TOWER: &str = "registertower";
+pub const RPC_REGISTER_TOWER_DESC: &str =
+    "Registers the client public key (user id) with the tower";
+pub const RPC_GET_REGISTRATION_RECEIPT: &str = "getregistrationreceipt";
+pub const RPC_GET_REGISTRATION_RECEIPT_DESC: &str =
+    "Gets the latest registration receipt given a tower id";
+pub const RPC_GET_APPOINTMENT: &str = "getappointment";
+pub const RPC_GET_APPOINTMENT_DESC: &str =
+    "Gets appointment data from the tower given a tower id and a locator";
+pub const RPC_GET_APPOINTMENT_RECEIPT: &str = "getappointmentreceipt";
+pub const RPC_GET_APPOINTMENT_RECEIPT_DESC: &str =
+    "Gets a (local) appointment receipt given a tower id and a locator";
+pub const RPC_GET_SUBSCRIPTION_INFO: &str = "getsubscriptioninfo";
+pub const RPC_GET_SUBSCRIPTION_INFO_DESC: &str =
+    "Gets the subscription information directly from the tower";
+pub const RPC_LIST_TOWERS: &str = "listtowers";
+pub const RPC_LIST_TOWERS_DESC: &str = "Lists all registered towers";
+pub const RPC_GET_TOWER_INFO: &str = "gettowerinfo";
+pub const RPC_GET_TOWER_INFO_DESC: &str = "Shows the info about a tower given a tower id";
+pub const RPC_RETRY_TOWER: &str = "retrytower";
+pub const RPC_RETRY_TOWER_DESC: &str =
+    "Retries to send pending appointment to an unreachable tower";
+pub const RPC_ABANDON_TOWER: &str = "abandontower";
+pub const RPC_ABANDON_TOWER_DESC: &str = "Forgets about a tower and wipes all local data";
+
+/// Collections of hook names
+
+pub const HOOK_COMMITMENT_REVOCATION: &str = "commitment_revocation";

--- a/watchtower-plugin/src/lib.rs
+++ b/watchtower-plugin/src/lib.rs
@@ -7,6 +7,7 @@ use teos_common::appointment::{Appointment, Locator};
 use teos_common::receipts::AppointmentReceipt;
 use teos_common::TowerId;
 
+pub mod constants;
 pub mod convert;
 pub mod dbm;
 pub mod net;

--- a/watchtower-plugin/src/main.rs
+++ b/watchtower-plugin/src/main.rs
@@ -625,7 +625,7 @@ async fn main() -> Result<(), Error> {
         e
     })?;
 
-    let auto_retry_delay = u16::try_from(
+    let auto_retry_delay = u32::try_from(
         midstate
             .option(constants::WT_AUTO_RETRY_DELAY)
             .unwrap()

--- a/watchtower-plugin/src/retrier.rs
+++ b/watchtower-plugin/src/retrier.rs
@@ -49,7 +49,7 @@ pub struct RetryManager {
     wt_client: Arc<Mutex<WTClient>>,
     unreachable_towers: UnboundedReceiver<(TowerId, RevocationData)>,
     max_elapsed_time_secs: u16,
-    auto_retry_delay: u16,
+    auto_retry_delay: u32,
     max_interval_time_secs: u16,
     retriers: HashMap<TowerId, Arc<Retrier>>,
 }
@@ -59,7 +59,7 @@ impl RetryManager {
         wt_client: Arc<Mutex<WTClient>>,
         unreachable_towers: UnboundedReceiver<(TowerId, RevocationData)>,
         max_elapsed_time_secs: u16,
-        auto_retry_delay: u16,
+        auto_retry_delay: u32,
         max_interval_time_secs: u16,
     ) -> Self {
         RetryManager {
@@ -595,8 +595,8 @@ mod tests {
     use crate::net::http::ApiError;
     use crate::test_utils::get_dummy_add_appointment_response;
 
-    const LONG_AUTO_RETRY_DELAY: u16 = 60;
-    const SHORT_AUTO_RETRY_DELAY: u16 = 3;
+    const LONG_AUTO_RETRY_DELAY: u32 = 60;
+    const SHORT_AUTO_RETRY_DELAY: u32 = 3;
     const API_DELAY: f64 = 0.5;
     const MAX_ELAPSED_TIME: u16 = 2;
     const MAX_INTERVAL_TIME: u16 = 1;


### PR DESCRIPTION
Options include helper functions to convert them to their proper type after
`cln-plugin=0.1.2`. Use that to reduce the option parsing boilerplate.

Also move all names, descriptions and default values for options, rpc_methods and hooks
to a new file.