### PR TITLE
Adds teosd.service to run teos as daemon

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,3 +15,7 @@ cargo test
 ```
 
 Please refer to the cargo documentation for more detailed instructions.
+
+# Systemd setup for backend
+
+Refer to [contrib](contrib/init/README.md) for a detailed explanation of how to set up your systemd service for `teosd`.

--- a/contrib/init/README.md
+++ b/contrib/init/README.md
@@ -1,0 +1,42 @@
+**This document guides you into how to set-up a systemd service to run `teosd`.**
+
+Since the teos service requires bitcoin to run, it is strongly recommended to also create a [system service for bitcoin](https://github.com/bitcoin/bitcoin/blob/master/contrib/init/bitcoind.service).
+
+Once you have set the bitcoin service, proceed to copy [teosd.service](teosd.service) to the systemd folder, that is, if running from this folder:
+
+```
+cp teosd.service /etc/systemd/system
+```
+
+You can also create a file called `teosd.service` in the systemd folder and copy the content of [teosd.service](teosd.service) to it:
+
+```
+sudo vim /etc/systemd/system/teosd.service
+```
+
+Notice the provided service file is using `teos` both as user and group for the service, so you may want to update that if that is not the configuration you are intending to use. Here are the lines to be updated:
+
+```
+[Service]
+ExecStart=/home/<user>/.cargo/bin/teosd
+SyslogIdentifier=<user>
+
+# Directory creation and permissions
+####################################
+User=<user>
+Group=<group>
+```
+
+The next step is enabling the service. You can do so by running:
+
+```
+sudo systemctl enable teosd.service
+```
+
+Finally, you can start the service by running:
+
+```
+sudo systemctl start teosd.service
+```
+
+From that point on, the tower will be run every time your system is turned on, and restarted if needed.

--- a/contrib/init/teosd.service
+++ b/contrib/init/teosd.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=The Eye of Satoshi daemon
+After=bitcoind.service network.target
+Requires=bitcoind.service
+Wants=network.target
+
+[Service]
+ExecStart=/home/teos/.cargo/bin/teosd
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=teos
+
+# Process management
+####################
+Type=simple
+Restart=on-failure
+TimeoutSec=300
+RestartSec=60
+
+# Directory creation and permissions
+####################################
+User=teos
+Group=teos
+
+# Hardening measures
+####################
+# Provide a private /tmp and /var/tmp.
+PrivateTmp=true
+
+# Mount /usr, /boot/ and /etc read-only for the process.
+ProtectSystem=full
+
+# Disallow the process and all of its children to gain
+# new privileges through execve().
+NoNewPrivileges=true
+
+# Use a new /dev namespace only populated with API pseudo devices
+# such as /dev/null, /dev/zero and /dev/random.
+PrivateDevices=true
+
+# Deny the creation of writable and executable memory mappings.
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This builds on top of the work from the work by @decentralizedb and @jochemin in #138. It is mainly just re-arranging the code and readmes to fit https://github.com/talaia-labs/rust-teos/pull/138#pullrequestreview-1195570409, but they did all the heavy lifting.

Close #138 