### PR TITLE
Updates teosd.service

### DIFF
--- a/contrib/init/teosd.service
+++ b/contrib/init/teosd.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=The Eye of Satoshi daemon
-After=bitcoind.service network.target
 Requires=bitcoind.service
-Wants=network.target
+After=bitcoind.service 
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/home/teos/.cargo/bin/teosd

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -158,7 +158,7 @@ async fn main() {
                 _ => e.to_string(),
             };
             log::error!("Failed to connect to bitcoind. Error: {}", e_msg);
-            return;
+            std::process::exit(1);
         }
     };
 


### PR DESCRIPTION
Updates `teosd.service` to add `tor.service` to `Wants=`, so it waits for tor to be initialized if it has to.

Will keep this open for now though, more modifications may pop up while testing v0.2.0-rc1.