### PR TITLE
Formats strings to use inline params when possible

### DIFF
--- a/teos-common/src/appointment.rs
+++ b/teos-common/src/appointment.rs
@@ -95,7 +95,7 @@ impl std::str::FromStr for AppointmentStatus {
             "being_watched" => Ok(AppointmentStatus::BeingWatched),
             "dispute_responded" => Ok(AppointmentStatus::DisputeResponded),
             "not_found" => Ok(AppointmentStatus::NotFound),
-            _ => Err(format!("Unknown status: {}", s)),
+            _ => Err(format!("Unknown status: {s}")),
         }
     }
 }
@@ -107,7 +107,7 @@ impl fmt::Display for AppointmentStatus {
             AppointmentStatus::DisputeResponded => "dispute_responded",
             AppointmentStatus::NotFound => "not_found",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/teos-common/src/lib.rs
+++ b/teos-common/src/lib.rs
@@ -75,8 +75,7 @@ impl TryFrom<serde_json::Value> for UserId {
                     UserId::try_from(a.pop().unwrap())
                 } else {
                     Err(format!(
-                        "Unexpected json format. Expected a single parameter. Received: {}",
-                        param_count
+                        "Unexpected json format. Expected a single parameter. Received: {param_count}"
                     ))
                 }
             }
@@ -84,8 +83,7 @@ impl TryFrom<serde_json::Value> for UserId {
                 let param_count = m.len();
                 if param_count > 1 {
                     Err(format!(
-                        "Unexpected json format. Expected a single parameter. Received: {}",
-                        param_count
+                        "Unexpected json format. Expected a single parameter. Received: {param_count}"
                     ))
                 } else {
                     UserId::try_from(json!(m
@@ -95,8 +93,7 @@ impl TryFrom<serde_json::Value> for UserId {
                 }
             }
             _ => Err(format!(
-                "Unexpected request format. Expected: user_id/tower_id. Received: '{}'",
-                value
+                "Unexpected request format. Expected: user_id/tower_id. Received: '{value}'"
             )),
         }
     }

--- a/teos-common/src/net/http.rs
+++ b/teos-common/src/net/http.rs
@@ -22,6 +22,6 @@ impl std::fmt::Display for Endpoint {
 
 impl Endpoint {
     pub fn path(&self) -> String {
-        format!("/{}", self)
+        format!("/{self}")
     }
 }

--- a/teos-common/src/net/mod.rs
+++ b/teos-common/src/net/mod.rs
@@ -27,7 +27,7 @@ impl std::str::FromStr for AddressType {
         match s {
             "ipv4" => Ok(AddressType::IpV4),
             "torv3" => Ok(AddressType::TorV3),
-            _ => Err(format!("Unknown type: {}", s)),
+            _ => Err(format!("Unknown type: {s}")),
         }
     }
 }
@@ -38,7 +38,7 @@ impl fmt::Display for AddressType {
             AddressType::IpV4 => "ipv4",
             AddressType::TorV3 => "torv3",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/teos/src/api/http.rs
+++ b/teos/src/api/http.rs
@@ -36,14 +36,14 @@ impl ApiError {
 
     fn missing_field(field_name: &str) -> Rejection {
         reject::custom(Self::new(
-            format!("missing field `{}`", field_name),
+            format!("missing field `{field_name}`"),
             errors::MISSING_FIELD,
         ))
     }
 
     fn empty_field(field_name: &str) -> Rejection {
         reject::custom(Self::new(
-            format!("`{}` field is empty", field_name),
+            format!("`{field_name}` field is empty"),
             errors::EMPTY_FIELD,
         ))
     }
@@ -51,8 +51,7 @@ impl ApiError {
     fn wrong_field_length(field_name: &str, field_size: usize, expected_size: usize) -> Rejection {
         reject::custom(Self::new(
             format!(
-                "Wrong `{}` field size. Expected {}, received {}",
-                field_name, expected_size, field_size
+                "Wrong `{field_name}` field size. Expected {expected_size}, received {field_size}"
             ),
             errors::WRONG_FIELD_SIZE,
         ))
@@ -104,7 +103,7 @@ fn parse_grpc_response<T: serde::Serialize>(
         }
         Err(s) => {
             let (status_code, error_code) = match_status(&s);
-            log::debug!("Request failed, error_code={}", error_code);
+            log::debug!("Request failed, error_code={error_code}");
             log::debug!("Response: {}", serde_json::json!(s.message()));
             (
                 reply::json(&ApiError::new(s.message().into(), error_code)),

--- a/teos/src/api/internal.rs
+++ b/teos/src/api/internal.rs
@@ -133,7 +133,7 @@ impl PublicTowerServices for Arc<InternalAPI> {
                 )),
                 AddAppointmentFailure::SubscriptionExpired(x) => Err(Status::new(
                     Code::Unauthenticated,
-                    format!("Your subscription expired at {}", x),
+                    format!("Your subscription expired at {x}"),
                 )),
                 AddAppointmentFailure::AlreadyTriggered => Err(Status::new(
                     Code::AlreadyExists,
@@ -191,7 +191,7 @@ impl PublicTowerServices for Arc<InternalAPI> {
                 )),
                 GetAppointmentFailure::SubscriptionExpired(x) => Err(Status::new(
                     Code::Unauthenticated,
-                    format!("Your subscription expired at {}", x),
+                    format!("Your subscription expired at {x}"),
                 )),
             },
         }
@@ -213,7 +213,7 @@ impl PublicTowerServices for Arc<InternalAPI> {
                 ),
                 GetSubscriptionInfoFailure::SubscriptionExpired(x) => Status::new(
                     Code::Unauthenticated,
-                    format!("Your subscription expired at {}", x),
+                    format!("Your subscription expired at {x}"),
                 ),
             })?;
 

--- a/teos/src/api/tor.rs
+++ b/teos/src/api/tor.rs
@@ -49,7 +49,7 @@ impl TorAPI {
         log::info!("Loading Tor secret key from disk");
         let key = fs::read(path.join("onion_v3_sk"))
             .await
-            .map_err(|e| log::warn!("Tor secret key cannot be loaded. {}", e))
+            .map_err(|e| log::warn!("Tor secret key cannot be loaded. {e}"))
             .ok()?;
         let key: [u8; 64] = key
             .try_into()
@@ -62,7 +62,7 @@ impl TorAPI {
     /// Stores a Tor key to disk.
     async fn store_sk(key: &TorSecretKeyV3, path: PathBuf) {
         if let Err(e) = fs::write(path.join("onion_v3_sk"), key.as_bytes()).await {
-            log::error!("Cannot store Tor secret key. {}", e);
+            log::error!("Cannot store Tor secret key. {e}");
         }
     }
 
@@ -125,7 +125,7 @@ impl TorAPI {
             .map_err(|e| {
                 Error::new(
                     ErrorKind::Other,
-                    format!("failed to create onion hidden service: {}", e),
+                    format!("failed to create onion hidden service: {e}"),
                 )
             })?;
 

--- a/teos/src/bitcoin_cli.rs
+++ b/teos/src/bitcoin_cli.rs
@@ -79,7 +79,7 @@ impl<'a> BitcoindClient<'a> {
         teos_network: &'a str,
     ) -> std::io::Result<BitcoindClient<'a>> {
         let http_endpoint = HttpEndpoint::for_host(host.to_owned()).with_port(port);
-        let rpc_credentials = base64::encode(&format!("{}:{}", rpc_user, rpc_password));
+        let rpc_credentials = base64::encode(&format!("{rpc_user}:{rpc_password}"));
         let bitcoind_rpc_client = RpcClient::new(&rpc_credentials, http_endpoint)?;
 
         let client = Self {
@@ -97,10 +97,7 @@ impl<'a> BitcoindClient<'a> {
         if btc_network != teos_network {
             Err(Error::new(
                 ErrorKind::InvalidInput,
-                format!(
-                    "bitcoind is running on {} but teosd is set to run on {}",
-                    btc_network, teos_network
-                ),
+                format!("bitcoind is running on {btc_network} but teosd is set to run on {teos_network}"),
             ))
         } else {
             Ok(client)

--- a/teos/src/carrier.rs
+++ b/teos/src/carrier.rs
@@ -96,11 +96,11 @@ impl Carrier {
             Err(JsonRpcError(RpcError(rpcerr))) => match rpcerr.code {
                 // Since we're pushing a raw transaction to the network we can face several rejections
                 rpc_errors::RPC_VERIFY_REJECTED => {
-                    log::error!("Transaction couldn't be broadcast. {:?}", rpcerr);
+                    log::error!("Transaction couldn't be broadcast. {rpcerr:?}");
                     ConfirmationStatus::Rejected(rpc_errors::RPC_VERIFY_REJECTED)
                 }
                 rpc_errors::RPC_VERIFY_ERROR => {
-                    log::error!("Transaction couldn't be broadcast. {:?}", rpcerr);
+                    log::error!("Transaction couldn't be broadcast. {rpcerr:?}");
                     ConfirmationStatus::Rejected(rpc_errors::RPC_VERIFY_ERROR)
                 }
                 rpc_errors::RPC_VERIFY_ALREADY_IN_CHAIN => {
@@ -122,10 +122,7 @@ impl Carrier {
                 }
                 _ => {
                     // If something else happens (unlikely but possible) log it so we can treat it in future releases.
-                    log::error!(
-                        "Unexpected rpc error when calling sendrawtransaction: {:?}",
-                        rpcerr
-                    );
+                    log::error!("Unexpected rpc error when calling sendrawtransaction: {rpcerr:?}");
                     ConfirmationStatus::Rejected(errors::UNKNOWN_JSON_RPC_EXCEPTION)
                 }
             },
@@ -137,7 +134,7 @@ impl Carrier {
             }
             Err(e) => {
                 // TODO: This may need finer catching.
-                log::error!("Unexpected error when calling sendrawtransaction: {:?}", e);
+                log::error!("Unexpected error when calling sendrawtransaction: {e:?}");
                 ConfirmationStatus::Rejected(errors::UNKNOWN_JSON_RPC_EXCEPTION)
             }
         };
@@ -159,15 +156,12 @@ impl Carrier {
             Ok(tx) => tx.blockhash.is_none(),
             Err(JsonRpcError(RpcError(rpcerr))) => match rpcerr.code {
                 rpc_errors::RPC_INVALID_ADDRESS_OR_KEY => {
-                    log::info!("Transaction not found in mempool: {}", txid);
+                    log::info!("Transaction not found in mempool: {txid}");
                     false
                 }
                 e => {
                     // DISCUSS: This could result in a silent error with unknown consequences
-                    log::error!(
-                        "Unexpected error code when calling getrawtransaction: {}",
-                        e
-                    );
+                    log::error!("Unexpected error code when calling getrawtransaction: {e}");
                     false
                 }
             },
@@ -180,10 +174,7 @@ impl Carrier {
             // TODO: This may need finer catching.
             Err(e) => {
                 // DISCUSS: This could result in a silent error with unknown consequences
-                log::error!(
-                    "Unexpected JSONRPCError when calling getrawtransaction: {}",
-                    e
-                );
+                log::error!("Unexpected JSONRPCError when calling getrawtransaction: {e}");
                 false
             }
         }

--- a/teos/src/chain_monitor.rs
+++ b/teos/src/chain_monitor.rs
@@ -100,7 +100,7 @@ where
             Err(e) => match e.kind() {
                 BlockSourceErrorKind::Persistent => {
                     // FIXME: This may need finer catching
-                    log::error!("Unexpected persistent error: {:?}", e);
+                    log::error!("Unexpected persistent error: {e:?}");
                 }
                 BlockSourceErrorKind::Transient => {
                     // Treating all transient as connection errors at least for now.

--- a/teos/src/cli.rs
+++ b/teos/src/cli.rs
@@ -20,7 +20,7 @@ async fn main() {
 
     // Create data dir if it does not exist
     fs::create_dir_all(&path).await.unwrap_or_else(|e| {
-        eprintln!("Cannot create data dir: {:?}", e);
+        eprintln!("Cannot create data dir: {e:?}");
         std::process::exit(1);
     });
 
@@ -51,13 +51,13 @@ async fn main() {
         .expect("Cannot create channel from endpoint")
         .tls_config(tls)
         .unwrap_or_else(|e| {
-            eprintln!("Could not configure tls: {:?}", e);
+            eprintln!("Could not configure tls: {e:?}");
             std::process::exit(1);
         })
         .connect()
         .await
         .unwrap_or_else(|e| {
-            eprintln!("Could not connect to tower: {:?}", e);
+            eprintln!("Could not connect to tower: {e:?}");
             std::process::exit(1);
         });
 
@@ -83,7 +83,7 @@ async fn main() {
                         Err(status) => println!("{}", status.message()),
                     }
                 }
-                Err(e) => println!("{}", e),
+                Err(e) => println!("{e}"),
             };
         }
         Command::GetTowerInfo => {
@@ -109,7 +109,7 @@ async fn main() {
                         Err(status) => println!("{}", status.message()),
                     }
                 }
-                Err(e) => println!("{}", e),
+                Err(e) => println!("{e}"),
             };
         }
         Command::Stop => {

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -20,7 +20,7 @@ pub fn from_file<T: Default + serde::de::DeserializeOwned>(path: PathBuf) -> T {
     match std::fs::read(path) {
         Ok(file_content) => toml::from_slice::<T>(&file_content).map_or_else(
             |e| {
-                eprintln!("Couldn't parse config file: {}", e);
+                eprintln!("Couldn't parse config file: {e}");
                 T::default()
             },
             |config| config,

--- a/teos/src/dbm.rs
+++ b/teos/src/dbm.rs
@@ -107,11 +107,11 @@ impl DBM {
             ],
         ) {
             Ok(x) => {
-                log::debug!("User successfully stored: {}", user_id);
+                log::debug!("User successfully stored: {user_id}");
                 Ok(x)
             }
             Err(e) => {
-                log::error!("Couldn't store user: {}. Error: {:?}", user_id, e);
+                log::error!("Couldn't store user: {user_id}. Error: {e:?}");
                 Err(e)
             }
         }
@@ -131,10 +131,10 @@ impl DBM {
             ],
         ) {
             Ok(_) => {
-                log::debug!("User's info successfully updated: {}", user_id);
+                log::debug!("User's info successfully updated: {user_id}");
             }
             Err(_) => {
-                log::error!("User not found, data cannot be updated: {}", user_id);
+                log::error!("User not found, data cannot be updated: {user_id}");
             }
         }
     }
@@ -205,18 +205,15 @@ impl DBM {
             let query = "DELETE FROM users WHERE user_id IN ".to_owned();
             let placeholders = format!("(?{})", (", ?").repeat(chunk.len() - 1));
 
-            match tx.execute(
-                &format!("{}{}", query, placeholders),
-                params_from_iter(chunk),
-            ) {
+            match tx.execute(&format!("{query}{placeholders}"), params_from_iter(chunk)) {
                 Ok(_) => log::debug!("Users deletion added to db transaction"),
-                Err(e) => log::error!("Couldn't add deletion query to transaction. Error: {:?}", e),
+                Err(e) => log::error!("Couldn't add deletion query to transaction. Error: {e:?}"),
             }
         }
 
         match tx.commit() {
             Ok(_) => log::debug!("Users successfully deleted"),
-            Err(e) => log::error!("Couldn't delete users. Error: {:?}", e),
+            Err(e) => log::error!("Couldn't delete users. Error: {e:?}"),
         }
 
         (users.len() as f64 / limit as f64).ceil() as usize
@@ -242,11 +239,11 @@ impl DBM {
             ],
         ) {
             Ok(x) => {
-                log::debug!("Appointment successfully stored: {}", uuid);
+                log::debug!("Appointment successfully stored: {uuid}");
                 Ok(x)
             }
             Err(e) => {
-                log::error!("Couldn't store appointment: {}. Error: {:?}", uuid, e);
+                log::error!("Couldn't store appointment: {uuid}. Error: {e:?}");
                 Err(e)
             }
         }
@@ -268,10 +265,10 @@ impl DBM {
             ],
         ) {
             Ok(_) => {
-                log::debug!("Appointment successfully updated: {}", uuid);
+                log::debug!("Appointment successfully updated: {uuid}");
             }
             Err(_) => {
-                log::error!("Appointment not found, data cannot be updated: {}", uuid);
+                log::error!("Appointment not found, data cannot be updated: {uuid}");
             }
         }
     }
@@ -360,10 +357,10 @@ impl DBM {
         let query = "DELETE FROM appointments WHERE UUID=(?)";
         match self.remove_data(query, params![uuid.to_vec()]) {
             Ok(_) => {
-                log::debug!("Appointment successfully removed: {}", uuid);
+                log::debug!("Appointment successfully removed: {uuid}");
             }
             Err(_) => {
-                log::error!("Appointment not found, data cannot be removed: {}", uuid);
+                log::error!("Appointment not found, data cannot be removed: {uuid}");
             }
         }
     }
@@ -386,12 +383,9 @@ impl DBM {
             let query = "DELETE FROM appointments WHERE UUID IN ".to_owned();
             let placeholders = format!("(?{})", (", ?").repeat(chunk.len() - 1));
 
-            match tx.execute(
-                &format!("{}{}", query, placeholders),
-                params_from_iter(chunk),
-            ) {
+            match tx.execute(&format!("{query}{placeholders}"), params_from_iter(chunk)) {
                 Ok(_) => log::debug!("Appointments deletion added to db transaction"),
-                Err(e) => log::error!("Couldn't add deletion query to transaction. Error: {:?}", e),
+                Err(e) => log::error!("Couldn't add deletion query to transaction. Error: {e:?}"),
             }
         }
 
@@ -399,13 +393,13 @@ impl DBM {
             let query = "UPDATE users SET available_slots=(?1) WHERE user_id=(?2)";
             match tx.execute(query, params![info.available_slots, id.to_vec(),]) {
                 Ok(_) => log::debug!("User update added to db transaction"),
-                Err(e) => log::error!("Couldn't add update query to transaction. Error: {:?}", e),
+                Err(e) => log::error!("Couldn't add update query to transaction. Error: {e:?}"),
             };
         }
 
         match tx.commit() {
             Ok(_) => log::debug!("Appointments successfully deleted"),
-            Err(e) => log::error!("Couldn't delete appointments. Error: {:?}", e),
+            Err(e) => log::error!("Couldn't delete appointments. Error: {e:?}"),
         }
 
         (appointments.len() as f64 / limit as f64).ceil() as usize
@@ -446,11 +440,11 @@ impl DBM {
             ],
         ) {
             Ok(x) => {
-                log::debug!("Tracker successfully stored: {}", uuid);
+                log::debug!("Tracker successfully stored: {uuid}");
                 Ok(x)
             }
             Err(e) => {
-                log::error!("Couldn't store tracker: {}. Error: {:?}", uuid, e);
+                log::error!("Couldn't store tracker: {uuid}. Error: {e:?}");
                 Err(e)
             }
         }

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -72,7 +72,7 @@ async fn main() {
 
     // Create data dir if it does not exist
     fs::create_dir_all(&path).unwrap_or_else(|e| {
-        eprintln!("Cannot create data dir: {:?}", e);
+        eprintln!("Cannot create data dir: {e:?}");
         std::process::exit(1);
     });
 
@@ -81,7 +81,7 @@ async fn main() {
     let is_default = conf.is_default();
     conf.patch_with_options(opt);
     conf.verify().unwrap_or_else(|e| {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         std::process::exit(1);
     });
 
@@ -112,7 +112,7 @@ async fn main() {
     // Create network dir
     let path_network = path.join(conf.btc_network.clone());
     fs::create_dir_all(&path_network).unwrap_or_else(|e| {
-        eprintln!("Cannot create network dir: {:?}", e);
+        eprintln!("Cannot create network dir: {e:?}");
         std::process::exit(1);
     });
     let dbm = Arc::new(Mutex::new(
@@ -136,7 +136,7 @@ async fn main() {
             }
         }
     };
-    log::info!("tower_id: {}", tower_pk);
+    log::info!("tower_id: {tower_pk}");
 
     // Initialize our bitcoind client
     let (bitcoin_cli, bitcoind_reachable) = match BitcoindClient::new(
@@ -157,7 +157,7 @@ async fn main() {
                 ErrorKind::InvalidData => "invalid btcrpcuser or btcrpcpassword".into(),
                 _ => e.to_string(),
             };
-            log::error!("Failed to connect to bitcoind. Error: {}", e_msg);
+            log::error!("Failed to connect to bitcoind. Error: {e_msg}");
             std::process::exit(1);
         }
     };
@@ -171,7 +171,7 @@ async fn main() {
     };
     let rpc = Arc::new(
         Client::new(
-            &format!("{}{}:{}", schema, conf.btc_rpc_connect, conf.btc_rpc_port),
+            &format!("{schema}{}:{}", conf.btc_rpc_connect, conf.btc_rpc_port),
             Auth::UserPass(conf.btc_rpc_user.clone(), conf.btc_rpc_password.clone()),
         )
         .unwrap(),
@@ -196,8 +196,7 @@ async fn main() {
     // could pull from the backend. Adding this functionality just for regtest seemed unnecessary though, hence the check.
     if tip.height < IRREVOCABLY_RESOLVED {
         log::error!(
-            "Not enough blocks to start teosd (required: {}). Mine at least {} more",
-            IRREVOCABLY_RESOLVED,
+            "Not enough blocks to start teosd (required: {IRREVOCABLY_RESOLVED}). Mine at least {} more",
             IRREVOCABLY_RESOLVED - tip.height
         );
         std::process::exit(1);
@@ -323,7 +322,7 @@ async fn main() {
     // Generate mtls certificates to data directory so the admin can securely connect
     // to the server to perform administrative tasks.
     let (identity, ca_cert) = tls_init(&path).unwrap_or_else(|e| {
-        eprintln!("Couldn't generate tls certificates: {:?}", e);
+        eprintln!("Couldn't generate tls certificates: {e:?}");
         std::process::exit(1);
     });
 
@@ -370,7 +369,7 @@ async fn main() {
                 .expose_onion_service(tor_service_ready, shutdown_signal_tor)
                 .await
             {
-                eprintln!("Cannot connect to the Tor backend: {}", e);
+                eprintln!("Cannot connect to the Tor backend: {e}");
                 std::process::exit(1);
             }
         }));

--- a/teos/src/responder.rs
+++ b/teos/src/responder.rs
@@ -263,7 +263,7 @@ impl Responder {
             .unwrap()
             .store_tracker(uuid, &tracker)
             .unwrap();
-        log::info!("New tracker added (uuid={}).", uuid);
+        log::info!("New tracker added (uuid={uuid})");
     }
 
     /// Checks whether a given tracker can be found in the [Responder].
@@ -318,7 +318,7 @@ impl Responder {
                     // Tracker is deep enough in the chain, it can be deleted
                     completed_trackers.insert(*uuid);
                 } else {
-                    log::info!("{} received a confirmation (count={})", uuid, confirmations);
+                    log::info!("{uuid} received a confirmation (count={confirmations})");
                 }
             } else if txids.contains(&tracker.penalty_txid) {
                 // First confirmation was received
@@ -423,9 +423,8 @@ impl Responder {
                     let status = carrier.send_transaction(&dispute_tx);
                     if let ConfirmationStatus::Rejected(e) = status {
                         log::error!(
-                        "Reorged dispute transaction rejected during rebroadcast: {} (reason: {:?})",
-                        dispute_tx.txid(),
-                        e
+                        "Reorged dispute transaction rejected during rebroadcast: {} (reason: {e})",
+                        dispute_tx.txid()
                     );
                         status
                     } else {
@@ -466,9 +465,9 @@ impl Responder {
         let mut tx_tracker_map = self.tx_tracker_map.lock().unwrap();
         for uuid in uuids.iter() {
             match reason {
-                DeletionReason::Completed => log::info!("Appointment completed. Penalty transaction was irrevocably confirmed: {}", uuid),
-                DeletionReason::Outdated => log::info!("Appointment couldn't be completed. Expiry reached but penalty didn't make it to the chain: {}", uuid),
-                DeletionReason::Rejected => log::info!("Appointment couldn't be completed. Either the dispute or the penalty txs where rejected during rebroadcast: {}", uuid),
+                DeletionReason::Completed => log::info!("Appointment completed. Penalty transaction was irrevocably confirmed: {uuid}"),
+                DeletionReason::Outdated => log::info!("Appointment couldn't be completed. Expiry reached but penalty didn't make it to the chain: {uuid}"),
+                DeletionReason::Rejected => log::info!("Appointment couldn't be completed. Either the dispute or the penalty txs where rejected during rebroadcast: {uuid}"),
             }
 
             match trackers.remove(uuid) {
@@ -488,7 +487,7 @@ impl Responder {
                 }
                 None => {
                     // This should never happen. Logging just in case so we can fix it if so
-                    log::error!("Completed tracker not found when cleaning: {}", uuid);
+                    log::error!("Completed tracker not found when cleaning: {uuid}");
                 }
             }
         }

--- a/teos/src/tls.rs
+++ b/teos/src/tls.rs
@@ -67,21 +67,14 @@ fn generate_or_load_identity(
     parent: Option<&Identity>,
 ) -> Result<Identity, GenCertificateFailure> {
     // Just our naming convention here.
-    let cert_path = directory.join(format!("{}.pem", filename));
-    let key_path = directory.join(format!("{}-key.pem", filename));
+    let cert_path = directory.join(format!("{filename}.pem"));
+    let key_path = directory.join(format!("{filename}-key.pem"));
     // Did we have to generate a new key? In that case we also need to regenerate the certificate.
     if !key_path.exists() || !cert_path.exists() {
-        log::debug!(
-            "Generating a new keypair in {:?}, it didn't exist",
-            &key_path
-        );
+        log::debug!("Generating a new keypair in {key_path:?}, it didn't exist",);
         let keypair = KeyPair::generate(&rcgen::PKCS_ECDSA_P256_SHA256)?;
         std::fs::write(&key_path, keypair.serialize_pem())?;
-        log::debug!(
-            "Generating a new certificate for key {:?} at {:?}",
-            &key_path,
-            &cert_path
-        );
+        log::debug!("Generating a new certificate for key {key_path:?} at {cert_path:?}",);
 
         // Configure the certificate we want.
         let subject_alt_names = vec!["cln".to_string(), "localhost".to_string()];

--- a/teos/src/tx_index.rs
+++ b/teos/src/tx_index.rs
@@ -189,7 +189,7 @@ where
             // Blocks should be disconnected from last backwards. Log if that's not the case so we can revisit this and fix it.
             if let Some(ref h) = self.blocks.pop_back() {
                 if h != block_hash {
-                    log::error!("Disconnected block does not match the oldest block stored in the TxIndex ({} != {})", block_hash, h);
+                    log::error!("Disconnected block does not match the oldest block stored in the TxIndex ({block_hash} != {h})");
                 }
             }
         } else {
@@ -204,7 +204,7 @@ where
         let ks = self.tx_in_block.remove(&h).unwrap();
         self.index.retain(|k, _| !ks.contains(k));
 
-        log::info!("Oldest block removed from index: {}", h);
+        log::info!("Oldest block removed from index: {h}");
     }
 }
 

--- a/watchtower-plugin/src/convert.rs
+++ b/watchtower-plugin/src/convert.rs
@@ -22,10 +22,10 @@ pub enum RegisterError {
 impl std::fmt::Display for RegisterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            RegisterError::InvalidId(x) => write!(f, "{}", x),
-            RegisterError::InvalidHost(x) => write!(f, "{}", x),
-            RegisterError::InvalidPort(x) => write!(f, "{}", x),
-            RegisterError::InvalidFormat(x) => write!(f, "{}", x),
+            RegisterError::InvalidId(x) => write!(f, "{x}"),
+            RegisterError::InvalidHost(x) => write!(f, "{x}"),
+            RegisterError::InvalidPort(x) => write!(f, "{x}"),
+            RegisterError::InvalidFormat(x) => write!(f, "{x}"),
         }
     }
 }
@@ -80,8 +80,7 @@ impl RegisterParams {
     fn with_port(self, port: u64) -> Result<Self, RegisterError> {
         if port > u16::MAX as u64 {
             Err(RegisterError::InvalidPort(format!(
-                "port must be a 16-byte integer. Received: {}",
-                port
+                "port must be a 16-byte integer. Received: {port}"
             )))
         } else {
             Ok(Self {
@@ -109,7 +108,7 @@ impl TryFrom<serde_json::Value> for RegisterParams {
                         let port = if let Some(p) = v.next() {
                             p.parse()
                                 .map(Some)
-                                .map_err(|_| RegisterError::InvalidPort(format!("Port is not a number: {}", p)))?
+                                .map_err(|_| RegisterError::InvalidPort(format!("Port is not a number: {p}")))?
                         } else {
                             None
                         };
@@ -128,14 +127,14 @@ impl TryFrom<serde_json::Value> for RegisterParams {
                         let tower_id = a.get(0).unwrap().as_str().ok_or_else(|| RegisterError::InvalidId("tower_id must be a string".to_string()))?;
                         let host = Some(a.get(1).unwrap().as_str().ok_or_else(|| RegisterError::InvalidHost("host must be a string".to_string()))?);
                         let port = if let Some(p) = a.get(2) {
-                            Some(p.as_u64().ok_or_else(|| RegisterError::InvalidPort(format!("port must be a number. Received: {}", p)))?)
+                            Some(p.as_u64().ok_or_else(|| RegisterError::InvalidPort(format!("port must be a number. Received: {p}")))?)
                         } else {
                             None
                         };
 
                         RegisterParams::new(tower_id, host, port)
                     }
-                    _ => Err(RegisterError::InvalidFormat(format!("Unexpected request format. The request needs 1-3 parameters. Received: {}", param_count))),
+                    _ => Err(RegisterError::InvalidFormat(format!("Unexpected request format. The request needs 1-3 parameters. Received: {param_count}"))),
                 }
             },
             serde_json::Value::Object(mut m) => {
@@ -143,7 +142,7 @@ impl TryFrom<serde_json::Value> for RegisterParams {
                 let param_count = m.len();
 
                  if m.is_empty() || param_count > allowed_keys.len() {
-                    Err(RegisterError::InvalidFormat(format!("Unexpected request format. The request needs 1-3 parameters. Received: {}", param_count)))
+                    Err(RegisterError::InvalidFormat(format!("Unexpected request format. The request needs 1-3 parameters. Received: {param_count}")))
                  } else if !m.contains_key(allowed_keys[0]){
                     Err(RegisterError::InvalidId(format!("{} is mandatory", allowed_keys[0])))
                  } else if !m.iter().all(|(k, _)| allowed_keys.contains(&k.as_str())) {
@@ -160,7 +159,7 @@ impl TryFrom<serde_json::Value> for RegisterParams {
                 }
             },
             _ => Err(RegisterError::InvalidFormat(
-                format!("Unexpected request format. Expected: 'tower_id[@host][:port]' or 'tower_id [host] [port]'. Received: '{}'", value),
+                format!("Unexpected request format. Expected: 'tower_id[@host][:port]' or 'tower_id [host] [port]'. Received: '{value}'"),
             )),
         }
     }
@@ -177,9 +176,9 @@ pub enum GetAppointmentError {
 impl std::fmt::Display for GetAppointmentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            GetAppointmentError::InvalidId(x) => write!(f, "{}", x),
-            GetAppointmentError::InvalidLocator(x) => write!(f, "{}", x),
-            GetAppointmentError::InvalidFormat(x) => write!(f, "{}", x),
+            GetAppointmentError::InvalidId(x) => write!(f, "{x}"),
+            GetAppointmentError::InvalidLocator(x) => write!(f, "{x}"),
+            GetAppointmentError::InvalidFormat(x) => write!(f, "{x}"),
         }
     }
 }
@@ -200,8 +199,7 @@ impl TryFrom<serde_json::Value> for GetAppointmentParams {
                 let param_count = a.len();
                 if param_count != 2 {
                     Err(GetAppointmentError::InvalidFormat(format!(
-                        "Unexpected request format. The request needs 2 parameter. Received: {}",
-                        param_count
+                        "Unexpected request format. The request needs 2 parameter. Received: {param_count}"
                     )))
                 } else {
                     let tower_id = if let Some(s) = a.get(0).unwrap().as_str() {
@@ -240,8 +238,7 @@ impl TryFrom<serde_json::Value> for GetAppointmentParams {
                 for k in allowed_keys.iter() {
                     if !m.contains_key(*k) {
                         return Err(GetAppointmentError::InvalidFormat(format!(
-                            "{} is mandatory",
-                            k
+                            "{k} is mandatory"
                         )));
                     }
                 }
@@ -255,8 +252,7 @@ impl TryFrom<serde_json::Value> for GetAppointmentParams {
                 GetAppointmentParams::try_from(json!(params))
             }
             _ => Err(GetAppointmentError::InvalidFormat(format!(
-                "Unexpected request format. Expected: tower_id locator. Received: '{}'",
-                value
+                "Unexpected request format. Expected: tower_id locator. Received: '{value}'"
             ))),
         }
     }
@@ -338,21 +334,18 @@ mod tests {
         #[test]
         fn test_try_from_json_string() {
             let ok = [
-                format!("{}@host:80", VALID_ID),
-                format!("{}@host", VALID_ID),
+                format!("{VALID_ID}@host:80"),
+                format!("{VALID_ID}@host"),
                 VALID_ID.to_string(),
             ];
             let wrong_id = ["", "id@host:80", "@host:80", "@:80"];
             let wrong_host = [
-                format!("{}@", VALID_ID),
-                format!("{}@ ", VALID_ID),
-                format!("{}@ host", VALID_ID),
-                format!("{}@:80", VALID_ID),
+                format!("{VALID_ID}@"),
+                format!("{VALID_ID}@ "),
+                format!("{VALID_ID}@ host"),
+                format!("{VALID_ID}@:80"),
             ];
-            let wrong_port = [
-                format!("{}@host:", VALID_ID),
-                format!("{}@host:port", VALID_ID),
-            ];
+            let wrong_port = [format!("{VALID_ID}@host:"), format!("{VALID_ID}@host:port")];
 
             for s in ok {
                 let v = serde_json::Value::Array(vec![serde_json::Value::String(s.to_string())]);

--- a/watchtower-plugin/src/dbm.rs
+++ b/watchtower-plugin/src/dbm.rs
@@ -393,10 +393,7 @@ impl DBM {
         // TODO: Can this be prepared instead of formatted (using ?1 seems to fail)?
         let mut stmt = self
             .connection
-            .prepare(&format!(
-                "SELECT locator FROM {} WHERE tower_id = ?",
-                status
-            ))
+            .prepare(&format!("SELECT locator FROM {status} WHERE tower_id = ?"))
             .unwrap();
 
         let mut rows = stmt.query(params![tower_id.to_vec()]).unwrap();
@@ -552,7 +549,7 @@ impl DBM {
         let mut appointments = Vec::new();
         let mut stmt = self
             .connection
-            .prepare(&format!("SELECT a.locator, a.encrypted_blob, a.to_self_delay FROM appointments as a, {} as t WHERE a.locator = t.locator AND t.tower_id = ?", table))
+            .prepare(&format!("SELECT a.locator, a.encrypted_blob, a.to_self_delay FROM appointments as a, {table} as t WHERE a.locator = t.locator AND t.tower_id = ?"))
             .unwrap();
         let mut rows = stmt.query([tower_id.to_vec()]).unwrap();
 

--- a/watchtower-plugin/src/net/http.rs
+++ b/watchtower-plugin/src/net/http.rs
@@ -62,7 +62,7 @@ pub async fn register(
     tower_net_addr: &NetAddr,
     proxy: &Option<ProxyInfo>,
 ) -> Result<RegistrationReceipt, RequestError> {
-    log::info!("Registering in the Eye of Satoshi (tower_id={})", tower_id);
+    log::info!("Registering in the Eye of Satoshi (tower_id={tower_id})");
     process_post_response(
         post_request(
             tower_net_addr,
@@ -95,13 +95,12 @@ pub async fn add_appointment(
     signature: &str,
 ) -> Result<(u32, AppointmentReceipt), AddAppointmentError> {
     log::debug!(
-        "Sending appointment {} to tower {}",
-        appointment.locator,
-        tower_id
+        "Sending appointment {} to tower {tower_id}",
+        appointment.locator
     );
     let (response, receipt) =
         send_appointment(tower_id, tower_net_addr, proxy, appointment, signature).await?;
-    log::debug!("Appointment accepted and signed by {}", tower_id);
+    log::debug!("Appointment accepted and signed by {tower_id}");
     log::debug!("Remaining slots: {}", response.available_slots);
     log::debug!("Start block: {}", response.start_block);
 
@@ -167,10 +166,10 @@ pub async fn post_request<S: Serialize>(
             reqwest::Client::builder()
                 .proxy(
                     reqwest::Proxy::http(proxy.get_socks_addr())
-                        .map_err(|e| RequestError::ConnectionError(format!("{}", e)))?,
+                        .map_err(|e| RequestError::ConnectionError(format!("{e}")))?,
                 )
                 .build()
-                .map_err(|e| RequestError::ConnectionError(format!("{}", e)))?
+                .map_err(|e| RequestError::ConnectionError(format!("{e}")))?
         } else {
             reqwest::Client::new()
         }
@@ -190,7 +189,7 @@ pub async fn post_request<S: Serialize>(
         .send()
         .await
         .map_err(|e| {
-            log::debug!("An error ocurred when sending data to the tower: {}", e);
+            log::debug!("An error ocurred when sending data to the tower: {e}");
             if e.is_connect() | e.is_timeout() {
                 RequestError::ConnectionError(
                     "Cannot connect to the tower. Connection refused".to_owned(),
@@ -210,7 +209,7 @@ pub async fn process_post_response<T: DeserializeOwned>(
     // TODO: Check if this can be switched for a map. Not sure how to handle async with maps
     match post_request {
         Ok(r) => r.json().await.map_err(|e| {
-            RequestError::DeserializeError(format!("Unexpected response body. Error: {}", e))
+            RequestError::DeserializeError(format!("Unexpected response body. Error: {e}"))
         }),
         Err(e) => Err(e),
     }

--- a/watchtower-plugin/src/wt_client.rs
+++ b/watchtower-plugin/src/wt_client.rs
@@ -46,7 +46,7 @@ impl std::fmt::Debug for RevocationData {
             f,
             "{}",
             match self {
-                RevocationData::Fresh(l) => format!("Fresh: {}", l),
+                RevocationData::Fresh(l) => format!("Fresh: {l}"),
                 RevocationData::Stale(hs) => format!(
                     "Stale: {:?}",
                     hs.iter().map(|l| l.to_string()).collect::<Vec<_>>()
@@ -90,7 +90,7 @@ impl WTClient {
     ) -> Self {
         // Create data dir if it does not exist
         fs::create_dir_all(&data_dir).await.unwrap_or_else(|e| {
-            log::error!("Cannot create data dir: {:?}", e);
+            log::error!("Cannot create data dir: {e:?}");
             std::process::exit(1);
         });
 
@@ -120,10 +120,7 @@ impl WTClient {
             }
         }
 
-        log::info!(
-            "Plugin watchtower client initialized. User id = {}",
-            user_id
-        );
+        log::info!("Plugin watchtower client initialized. User id = {user_id}");
 
         WTClient {
             towers,
@@ -206,14 +203,10 @@ impl WTClient {
             if tower.status != status {
                 tower.status = status
             } else {
-                log::debug!("{} status is already {}", tower_id, status)
+                log::debug!("{tower_id} status is already {status}")
             }
         } else {
-            log::error!(
-                "Cannot change tower status to {}. Unknown tower_id: {}",
-                status,
-                tower_id
-            );
+            log::error!("Cannot change tower status to {status}. Unknown tower_id: {tower_id}");
         }
     }
 
@@ -238,10 +231,7 @@ impl WTClient {
                 .store_appointment_receipt(tower_id, locator, available_slots, receipt)
                 .unwrap();
         } else {
-            log::error!(
-                "Cannot add appointment receipt to tower. Unknown tower_id: {}",
-                tower_id
-            );
+            log::error!("Cannot add appointment receipt to tower. Unknown tower_id: {tower_id}");
         }
     }
 
@@ -263,10 +253,7 @@ impl WTClient {
                 .store_pending_appointment(tower_id, appointment)
                 .unwrap();
         } else {
-            log::error!(
-                "Cannot add pending appointment to tower. Unknown tower_id: {}",
-                tower_id
-            );
+            log::error!("Cannot add pending appointment to tower. Unknown tower_id: {tower_id}");
         }
     }
 
@@ -279,10 +266,7 @@ impl WTClient {
                 .delete_pending_appointment(tower_id, locator)
                 .unwrap();
         } else {
-            log::error!(
-                "Cannot remove pending appointment to tower. Unknown tower_id: {}",
-                tower_id
-            );
+            log::error!("Cannot remove pending appointment to tower. Unknown tower_id: {tower_id}");
         }
     }
 
@@ -295,10 +279,7 @@ impl WTClient {
                 .store_invalid_appointment(tower_id, appointment)
                 .unwrap();
         } else {
-            log::error!(
-                "Cannot add invalid appointment to tower. Unknown tower_id: {}",
-                tower_id
-            );
+            log::error!("Cannot add invalid appointment to tower. Unknown tower_id: {tower_id}");
         }
     }
 
@@ -308,7 +289,7 @@ impl WTClient {
             self.dbm.store_misbehaving_proof(tower_id, &proof).unwrap();
             tower.status = TowerStatus::Misbehaving;
         } else {
-            log::error!("Cannot flag tower. Unknown tower_id: {}", tower_id);
+            log::error!("Cannot flag tower. Unknown tower_id: {tower_id}");
         }
     }
 


### PR DESCRIPTION
The rule of thumb seems to be (at least for now):

- No method / function calls
- No arithmetic operations
- No field access (foo.bar)
- No package access (foo::bar)
- Some additional limitations for `panic` (such as using a match variant)

This is due to clippy complaining about some, so I went ahead and updated all the ones I've seen.