### PR TITLE
fixup: record the correct port for the Tor interface

### DIFF
--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -293,7 +293,7 @@ async fn main() {
         .await;
         addresses.push(msgs::NetworkAddress::from_torv3(
             tor_api.get_onion_address(),
-            conf.api_port,
+            conf.onion_hidden_service_port,
         ));
 
         Some(tor_api)


### PR DESCRIPTION
Use `conf.onion_hidden_service_port`.

Closes #186 

cc/ @1010adigupta