### PR TITLE
Makes http::serve take a SockAddr instead of a starting

### DIFF
--- a/teos/src/api/http.rs
+++ b/teos/src/api/http.rs
@@ -290,12 +290,12 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Rejection> {
 
 pub async fn serve(
     http_bind: SocketAddr,
-    grpc_bind: String,
+    grpc_bind: SocketAddr,
     service_ready: Trigger,
     shutdown_signal: Listener,
 ) {
     let grpc_conn = loop {
-        match PublicTowerServicesClient::connect(grpc_bind.clone()).await {
+        match PublicTowerServicesClient::connect(format!("http://{grpc_bind}")).await {
             Ok(conn) => break conn,
             Err(_) => {
                 log::error!("Cannot connect to the gRPC server. Retrying shortly");


### PR DESCRIPTION
This is a pretty simple PR, but it was hurting my eyes seeing that much replication and weird variable naming with respect to the internal API.

In a nutshell, this simply makes `http::serve` take `grpc_bind` as `SocketAddr` instead of `String`, so we can get rid of a useless variable and rename things more accordingly. 