### PR TITLE
Makes teos-cli cannot connect to backend error message more friendly

### DIFF
--- a/teos/src/cli.rs
+++ b/teos/src/cli.rs
@@ -56,8 +56,8 @@ async fn main() {
         })
         .connect()
         .await
-        .unwrap_or_else(|e| {
-            eprintln!("Could not connect to tower: {e:?}");
+        .unwrap_or_else(|_| {
+            eprintln!("Could not connect to tower. Is teosd running?");
             std::process::exit(1);
         });
 


### PR DESCRIPTION
Let's not just spit a debug error when calling `teos-cli` pointing to an unreachable backend.