### PR TITLE
Adds --forceupdate to teosd

### DIFF
--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -102,6 +102,11 @@ pub struct Opt {
     #[structopt(long)]
     pub tor_support: bool,
 
+    /// Forces the tower to run even if the underlying chain has gone too far out of sync. This can only happen
+    /// if the node is being run in pruned mode.
+    #[structopt(long)]
+    pub force_update: bool,
+
     /// Tor control port [default: 9051]
     #[structopt(long)]
     pub tor_control_port: Option<u16>,
@@ -139,6 +144,7 @@ pub struct Config {
     pub debug: bool,
     pub deps_debug: bool,
     pub overwrite_key: bool,
+    pub force_update: bool,
 
     // General
     pub subscription_slots: u32,
@@ -198,6 +204,7 @@ impl Config {
         self.debug |= options.debug;
         self.deps_debug |= options.deps_debug;
         self.overwrite_key = options.overwrite_key;
+        self.force_update = options.force_update;
     }
 
     /// Verifies that [Config] is properly built.
@@ -290,6 +297,7 @@ impl Default for Config {
             debug: false,
             deps_debug: false,
             overwrite_key: false,
+            force_update: false,
             subscription_slots: 10000,
             subscription_duration: 4320,
             expiry_delta: 6,
@@ -325,6 +333,7 @@ mod tests {
                 debug: false,
                 deps_debug: false,
                 overwrite_key: false,
+                force_update: false,
             }
         }
     }


### PR DESCRIPTION
If a tower hasn't been running for a long time and the backend runs in pruned mode it could be the case that by the time the tower comes back online, the Last known block by the tower is not being known by the node anymore. In this situation, the tower cannot bootstrap normally, given the cache cannot be populated.

This commits adds a new argument to teosd (`--forceupdate`) that can be used to force a tower to update its last known block to the earliest known block by the backend under this situation. Notice that doing so may make the tower miss some of its state transitions (the ones triggered by missed blocks), so this must be done as a last resource.

Fixes #209 
Supersedes #212 

## Testing

This can be tested easily in regtest by running `bitcoind` with the (hidden, undocumented) `-fastprune` modifier. That would make blocks smaller and easier to prune. After that, you can prune the chain using `bitcoin-cli pruneblockchain x` where `x` is your target prune height. The pruning is not likely to happen to the exact block you specified, given block files are pruned as a whole, so the chain would be pruned to the closest value that allows a bock file to be deleted.

So the flow of testing should be:

1. Start `teosd` and mine a few blocks so there is a `last_known_block` known by the tower
2. Shut down the tower
3. Mine a few thousand more blocks
4. Call `bitcoin-cli pruneblockchain x` and checked the returned `y` value
5. If `y - IRREVOCABLY_RESOLVED < last_known_block_height`, continue, otherwise go back to `3.`
6. Run `teosd` again and test it with and without `--forceupdate`