### PR TITLE
Properly patches sendrawtransaction so it does not crash

### DIFF
--- a/watchtower-plugin/tests/test.py
+++ b/watchtower-plugin/tests/test.py
@@ -48,7 +48,7 @@ def test_watchtower(node_factory, bitcoind, teosd):
     locator = change_endianness(dispute_txid[32:])
 
     # Make sure l2's normal penalty_tx doesn't reach the network
-    l2.daemon.rpcproxy.mock_rpc("sendrawtransaction", lambda: None)
+    l2.daemon.rpcproxy.mock_rpc("sendrawtransaction", lambda _: {"result": None, "error": None, "id": "pytest"})
     l2.start()
 
     # The tower will react once the dispute gets confirmed. For now it is still watching for it


### PR DESCRIPTION
Currently, when mocking sendrawtransaction so it does nothing, the client will raise an exception given the picked lambda does not accept any params (and sendrawtransaction has some). Patches it so this does not happen.

This patch is pretty minimal, given the behavior wrt CLN does not change, but it feels better not to except here.