### PR TITLE
Add black check to Python files in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,3 +47,14 @@ jobs:
       - name: Run clippy
         run: |
           cargo clippy --all-features --all-targets --color always -- --deny warnings
+          
+  python-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Run black
+        uses: psf/black@stable
+        with:
+          src: "./watchtower-plugin/tests"
+          options: "--check -l 120"


### PR DESCRIPTION
Fixes #230 

**Description**
This PR adds a new job in the CI that checks the formatting of Python files using Black. This ensures that all Python files follow the same code styling guidelines, making the codebase cleaner and easier to read.

**Changes**
1. Modified `.github/workflows/build.yaml` to include a new job for Black checks.

Please let me know if any changes are required.