### PR TITLE
Improves reorg logic by checking whether we are on sync with the backend or not

### DIFF
--- a/teos/src/responder.rs
+++ b/teos/src/responder.rs
@@ -442,12 +442,9 @@ impl Responder {
                         dispute_tx.txid()
                     );
                         status
-                    } else if status.off_sync() {
-                        // If the dispute bounces because we are off-sync, we want to try again with the whole package. Hence, we leave this as
-                        // reorged.
-                        ConfirmationStatus::ReorgedOut
                     } else {
-                        // The dispute was accepted, so we can rebroadcast the penalty.
+                        // If the dispute is not rejected we can send the penalty.
+                        // Notice this covers both the dispute being accepted or bouncing, given bouncing will mean it is already on chain.
                         carrier.send_transaction(&penalty_tx)
                     }
                 }

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -700,11 +700,15 @@ impl chain::Listen for Watcher {
             for (uuid, breach) in valid_breaches {
                 log::info!("Notifying Responder and deleting appointment (uuid: {uuid})");
 
-                if let ConfirmationStatus::Rejected(_) = self.responder.handle_breach(
-                    uuid,
-                    breach,
-                    self.appointments.lock().unwrap()[&uuid].user_id,
-                ) {
+                if self
+                    .responder
+                    .handle_breach(
+                        uuid,
+                        breach,
+                        self.appointments.lock().unwrap()[&uuid].user_id,
+                    )
+                    .rejected()
+                {
                     appointments_to_delete.insert(uuid);
                 } else {
                     delivered_appointments.insert(uuid);


### PR DESCRIPTION
The current reorg logic does not really take into account whether we are on sync with the backend or not. On a first block connected after a reorg, it will try to send all reorged out data assuming it has knowledge of everything that is already confirmed or in the mempool. However, in a multi block reorg the backend could be at a height that the tower has not processed yet, hence some transactions may be on the chain but not on our internal `txindex`. Therefore, it could be the case that we try to re-send something that has been reorged-out and see it bounce. Under normal conditions, that would mean the transaction was confirmed a long time ago, since otherwise it would be in our index. However, in this case it may be that it is just confirmed in a subsequent block we haven't processed yet. This will lead to wrongly assuming the tracker was `IRREVOCABLY RESOLVED`, while in reality it may only have a few confirmations.

This patch fixes that. In the case of a transaction bouncing we will check whether we are on sync with the backend, and only if so consider the tracker as `IRREVOCABLY RESOLVED`. Otherwise, the tracker will be flagged as `OffSync` and retried until it bounces when we are on sync, or its status is updated on block processing.

For context, this edge case was introduced when adding support for prune mode. Before that (when `txindex` for the backend was required) we would have used `getrawtransaction` to check the confirmation count of the bouncing transaction.

I realized about this when reviewing #190, wrongly believing that this edge case was being introduced by the changes there.