### PR TITLE
Replace UUID with locator

### DIFF
--- a/teos/build.rs
+++ b/teos/build.rs
@@ -2,7 +2,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .extern_path(".common.teos.v2", "::teos-common::protos")
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .field_attribute("user_id", "#[serde(with = \"hex::serde\")]")
+        .field_attribute("GetUserRequest.user_id", "#[serde(with = \"hex::serde\")]")
         .field_attribute("tower_id", "#[serde(with = \"hex::serde\")]")
         .field_attribute(
             "user_ids",

--- a/teos/proto/teos/v2/appointment.proto
+++ b/teos/proto/teos/v2/appointment.proto
@@ -4,7 +4,8 @@ package teos.v2;
 import "common/teos/v2/appointment.proto";
 
 message GetAppointmentsRequest {
-  // Request the information of appointments with specific locator and user_id (optional) .
+  // Request the information of appointments with specific locator.
+  // If a user id is provided (optional), request only appointments belonging to that user. 
 
   bytes locator = 1;
   optional bytes user_id = 2;

--- a/teos/proto/teos/v2/appointment.proto
+++ b/teos/proto/teos/v2/appointment.proto
@@ -4,9 +4,10 @@ package teos.v2;
 import "common/teos/v2/appointment.proto";
 
 message GetAppointmentsRequest {
-  // Request the information of appointments with specific locator.
+  // Request the information of appointments with specific locator and user_id (optional) .
 
   bytes locator = 1;
+  optional bytes user_id = 2;
 }
 
 message GetAppointmentsResponse {

--- a/teos/src/cli_config.rs
+++ b/teos/src/cli_config.rs
@@ -31,6 +31,8 @@ pub struct GetUserData {
 pub struct GetAppointmentsData {
     /// The locator of the appointments (16-byte hexadecimal string).
     pub locator: String,
+    /// The user identifier (33-byte compressed public key).
+    pub user_id: Option<String>,
 }
 
 /// Holds all the command line options and commands.

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -18,13 +18,10 @@ pub fn data_dir_absolute_path(data_dir: String) -> PathBuf {
 
 pub fn from_file<T: Default + serde::de::DeserializeOwned>(path: &PathBuf) -> T {
     match std::fs::read(path) {
-        Ok(file_content) => toml::from_slice::<T>(&file_content).map_or_else(
-            |e| {
-                eprintln!("Couldn't parse config file: {e}");
-                T::default()
-            },
-            |config| config,
-        ),
+        Ok(file_content) => toml::from_slice::<T>(&file_content).unwrap_or_else(|e| {
+            eprintln!("Couldn't parse config file: {e}");
+            T::default()
+        }),
         Err(_) => T::default(),
     }
 }
@@ -392,7 +389,7 @@ mod tests {
         assert_eq!(config.api_bind, expected_value);
 
         // Check the rest of fields are equal. The easiest is to just the field back and compare with a clone
-        config.api_bind = config_clone.api_bind.clone();
+        config.api_bind.clone_from(&config_clone.api_bind);
         assert_eq!(config, config_clone);
     }
 

--- a/teos/src/dbm.rs
+++ b/teos/src/dbm.rs
@@ -338,13 +338,15 @@ impl DBM {
             "SELECT a.UUID, a.locator, a.encrypted_blob, a.to_self_delay, a.user_signature, a.start_block, a.user_id
                 FROM appointments as a LEFT JOIN trackers as t ON a.UUID=t.UUID WHERE t.UUID IS NULL".to_string();
 
-        // If a locator and an optional user_id were passed, filter based on it.
-        if let Some((_, user_id)) = locator_and_userid {
+        // If a locator was passed, filter based on it.
+        if locator_and_userid.is_some() {
             sql.push_str(" AND a.locator=(?1)");
-            if user_id.is_some() {
-                sql.push_str(" AND a.user_id=(?2)");
-            }
-        };
+        }
+
+        // If a user_id is passed, filter even more.
+        if locator_and_userid.is_some_and(|inner| inner.1.is_some()) {
+            sql.push_str(" AND a.user_id=(?2)");
+        }
 
         let mut stmt = self.connection.prepare(&sql).unwrap();
 
@@ -611,12 +613,14 @@ impl DBM {
             FROM trackers as t INNER JOIN appointments as a ON t.UUID=a.UUID"
             .to_string();
 
-        // If a locator and an optional user_id were passed, filter based on it.
-        if let Some((_, user_id)) = locator_and_userid {
+        // If a locator was passed, filter based on it.
+        if locator_and_userid.is_some() {
             sql.push_str(" AND a.locator=(?1)");
-            if user_id.is_some() {
-                sql.push_str(" AND a.user_id=(?2)");
-            }
+        }
+
+        // If a user_id is passed, filter even more.
+        if locator_and_userid.is_some_and(|inner| inner.1.is_some()) {
+            sql.push_str(" AND a.user_id=(?2)");
         }
 
         let mut stmt = self.connection.prepare(&sql).unwrap();
@@ -774,8 +778,8 @@ mod tests {
 
     use crate::rpc_errors;
     use crate::test_utils::{
-        generate_dummy_appointment, generate_dummy_appointment_with_user, generate_uuid,
-        get_random_tracker, get_random_tx, AVAILABLE_SLOTS, SUBSCRIPTION_EXPIRY,
+        generate_dummy_appointment, generate_dummy_appointment_with_user, generate_dummy_tracker,
+        generate_uuid, get_random_tracker, get_random_tx, AVAILABLE_SLOTS, SUBSCRIPTION_EXPIRY,
         SUBSCRIPTION_START,
     };
 
@@ -1201,7 +1205,7 @@ mod tests {
         let dispute_txid = dispute_tx.txid();
         let locator = Locator::new(dispute_txid);
 
-        // create user id
+        // Create user id
         let user_id = get_random_user_id();
         let user = UserInfo::new(AVAILABLE_SLOTS, SUBSCRIPTION_START, SUBSCRIPTION_EXPIRY);
         dbm.store_user(user_id, &user).unwrap();
@@ -1212,14 +1216,14 @@ mod tests {
         dbm.store_appointment(uuid, &appointment).unwrap();
         appointments.insert(uuid, appointment.clone());
 
-        // create random appointments
+        // Create random appointments
         for _ in 1..11 {
             let (uuid, appointment) = generate_dummy_appointment_with_user(user_id, None);
             dbm.store_appointment(uuid, &appointment).unwrap();
             appointments.insert(uuid, appointment);
         }
 
-        // Returns empty if no appointment matches both userid and locator
+        // Verify that no appointment is returned if there is not an exact match of user_id + locator
         assert_eq!(
             dbm.load_appointments(Some((locator, Some(get_random_user_id()))),),
             HashMap::new()
@@ -1229,17 +1233,17 @@ mod tests {
             HashMap::new()
         );
 
-        // Returns particular appointments if they match both userid and locator
+        // Verify that the expected appointment is returned, if the correct user_id and locator is given
         assert_eq!(
             dbm.load_appointments(Some((locator, Some(user_id))),),
             HashMap::from([(uuid, appointment)])
         );
 
-        // Create a tracker from existing appointment
-        let tracker = get_random_tracker(user_id, ConfirmationStatus::InMempoolSince(100));
+        // Create a tracker from the existing appointment
+        let tracker = generate_dummy_tracker(user_id, dispute_tx.clone());
         dbm.store_tracker(uuid, &tracker).unwrap();
 
-        // ensure that no tracker is returned
+        // Verify that an appointment is not returned, if it is triggered (there's a tracker for it)
         assert_eq!(
             dbm.load_appointments(Some((locator, Some(user_id))),),
             HashMap::new()
@@ -1622,9 +1626,8 @@ mod tests {
         let dispute_tx = get_random_tx();
         let dispute_txid = dispute_tx.txid();
         let locator = Locator::new(dispute_txid);
-        let status = ConfirmationStatus::InMempoolSince(42);
 
-        // create user id
+        // Create user id
         let user_id = get_random_user_id();
         let user = UserInfo::new(AVAILABLE_SLOTS, SUBSCRIPTION_START, SUBSCRIPTION_EXPIRY);
         dbm.store_user(user_id, &user).unwrap();
@@ -1632,20 +1635,20 @@ mod tests {
         // Create and store a particular tracker
         let (uuid, appointment) =
             generate_dummy_appointment_with_user(user_id, Some(&dispute_txid));
-        let tracker = get_random_tracker(user_id, status);
+        let tracker = generate_dummy_tracker(user_id, dispute_tx.clone());
         dbm.store_appointment(uuid, &appointment).unwrap();
         dbm.store_tracker(uuid, &tracker).unwrap();
         trackers.insert(uuid, tracker.clone());
 
-        // create random trackers
+        // Create random trackers
         for _ in 1..11 {
             let (uuid, appointment) = generate_dummy_appointment_with_user(user_id, None);
-            let tracker = get_random_tracker(user_id, status);
+            let tracker = generate_dummy_tracker(user_id, dispute_tx.clone());
             dbm.store_appointment(uuid, &appointment).unwrap();
             dbm.store_tracker(uuid, &tracker).unwrap();
         }
 
-        // Returns empty if no tracker matches both userid and locator
+        // Verify that no tracker is returned if there is not an exact match of user_id + locator
         assert_eq!(
             dbm.load_trackers(Some((locator, Some(get_random_user_id()))),),
             HashMap::new()
@@ -1655,7 +1658,7 @@ mod tests {
             HashMap::new()
         );
 
-        // Returns particular trackers if they match both userid and locator
+        // Verify that the expected tracker is returned if both the correct user_id and locator are provided
         assert_eq!(
             dbm.load_trackers(Some((locator, Some(user_id))),),
             HashMap::from([(uuid, tracker)])

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -341,6 +341,17 @@ pub(crate) fn get_random_tracker(
     TransactionTracker::new(breach, user_id, status)
 }
 
+pub(crate) fn generate_dummy_tracker(
+    user_id: UserId,
+    dispute_tx: Transaction,
+) -> TransactionTracker {
+    TransactionTracker::new(
+        Breach::new(dispute_tx.clone(), get_random_tx()),
+        user_id,
+        ConfirmationStatus::ConfirmedIn(100),
+    )
+}
+
 pub(crate) fn store_appointment_and_its_user(dbm: &DBM, appointment: &ExtendedAppointment) {
     dbm.store_user(
         appointment.user_id,

--- a/teos/src/tx_index.rs
+++ b/teos/src/tx_index.rs
@@ -378,7 +378,7 @@ mod tests {
             // Check that the block data is not in the cache anymore
             assert_eq!(cache.blocks().len(), cache.size - i - 1);
             assert!(!cache.blocks().contains(&header.block_hash()));
-            assert!(cache.tx_in_block.get(&header.block_hash()).is_none());
+            assert!(!cache.tx_in_block.contains_key(&header.block_hash()));
             for locator in locators.iter() {
                 assert!(!cache.contains_key(locator));
             }

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -423,7 +423,8 @@ impl Watcher {
         self.dbm.lock().unwrap().load_appointments(None)
     }
 
-    /// Gets all the appointments matching a specific locator and an optional user id from the [Watcher] (from the database).
+    /// Gets all the appointments matching a specific locator
+    /// If a user id is provided (optional), only the appointments matching that user are returned
     pub(crate) fn get_watcher_appointments_with_locator(
         &self,
         locator: Locator,
@@ -435,12 +436,12 @@ impl Watcher {
             .load_appointments(Some((locator, user_id)))
     }
 
-    /// Gets all the trackers stored in the [Responder] (from the database).
+    /// Gets all the trackers stored in the [Responder].
     pub(crate) fn get_all_responder_trackers(&self) -> HashMap<UUID, TransactionTracker> {
         self.dbm.lock().unwrap().load_trackers(None)
     }
 
-    /// Gets all the trackers matching a specific locator and an optional user id from the [Responder] (from the database).
+    /// Gets all the trackers matching a specific locator and an optional user id from the [Responder].
     pub(crate) fn get_responder_trackers_with_locator(
         &self,
         locator: Locator,

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -423,12 +423,16 @@ impl Watcher {
         self.dbm.lock().unwrap().load_appointments(None)
     }
 
-    /// Gets all the appointments matching a specific locator from the [Watcher] (from the database).
+    /// Gets all the appointments matching a specific locator and an optional user id from the [Watcher] (from the database).
     pub(crate) fn get_watcher_appointments_with_locator(
         &self,
         locator: Locator,
+        user_id: Option<UserId>,
     ) -> HashMap<UUID, ExtendedAppointment> {
-        self.dbm.lock().unwrap().load_appointments(Some(locator))
+        self.dbm
+            .lock()
+            .unwrap()
+            .load_appointments(Some((locator, user_id)))
     }
 
     /// Gets all the trackers stored in the [Responder] (from the database).
@@ -436,12 +440,16 @@ impl Watcher {
         self.dbm.lock().unwrap().load_trackers(None)
     }
 
-    /// Gets all the trackers matching s specific locator from the [Responder] (from the database).
+    /// Gets all the trackers matching a specific locator and an optional user id from the [Responder] (from the database).
     pub(crate) fn get_responder_trackers_with_locator(
         &self,
         locator: Locator,
+        user_id: Option<UserId>,
     ) -> HashMap<UUID, TransactionTracker> {
-        self.dbm.lock().unwrap().load_trackers(Some(locator))
+        self.dbm
+            .lock()
+            .unwrap()
+            .load_trackers(Some((locator, user_id)))
     }
 
     /// Gets the list of all registered user ids.

--- a/watchtower-plugin/src/main.rs
+++ b/watchtower-plugin/src/main.rs
@@ -385,7 +385,7 @@ async fn abandon_tower(
 ) -> Result<serde_json::Value, Error> {
     let tower_id = TowerId::try_from(v).map_err(|e| anyhow!(e))?;
     let mut state = plugin.state().lock().unwrap();
-    if state.towers.get(&tower_id).is_some() {
+    if state.towers.contains_key(&tower_id) {
         state.remove_tower(tower_id).unwrap();
         Ok(json!(format!("{tower_id} successfully abandoned")))
     } else {

--- a/watchtower-plugin/src/retrier.rs
+++ b/watchtower-plugin/src/retrier.rs
@@ -432,7 +432,7 @@ impl Retrier {
         // Create a new scope so we can get all the data only locking the WTClient once.
         let (tower_id, status, net_addr, user_id, user_sk, proxy) = {
             let wt_client = self.wt_client.lock().unwrap();
-            if wt_client.towers.get(&self.tower_id).is_none() {
+            if !wt_client.towers.contains_key(&self.tower_id) {
                 return Err(Error::permanent(RetryError::Abandoned));
             }
 


### PR DESCRIPTION
***Objective***
Ensure _**locators**_ are returned instead of __uuid's__  under appointments section when user details are fetched through the **cli** using the **getuser** command.

***Problem***
`locator` is an appropriate identifier for appointments  in the __Bolt13__ specification draft, which is also being used in the `getappointments` cli command , but in the `getuser` cli command __uuid__ is being used which can be confusing .  The  solution is ensure `getuser` cli command makes use of `locator` and not `uuid`.

***Changes***

- Modified internal.rs `get_user_info` function to make use of **locator** and not **uuid** when returning  _user appointments_ info.
- Modified internal.rs `get_user` test to reflect the change from **uuid** to **locator**.

***Scope Of Change***
This is a non critical change, as it only affects the **CLI**.

closes #229