### PR TITLE
Adds rpccookie to bitcoind auth methods

### DIFF
--- a/teos/src/conf_template.toml
+++ b/teos/src/conf_template.toml
@@ -12,8 +12,10 @@ rpc_port = 8814
 # bitcoind
 btc_network = "mainnet"
 btc_rpc_user = "CSW"
+## Notice only user+password **OR** cookie is allowed as rpc auth, any other combination would be rejected
 btc_rpc_password = "NotSatoshi"
 btc_rpc_connect = "localhost"
+btc_rpc_cookie = "~/.bitcoin/.cookie"
 btc_rpc_port = 8332
 
 # Flags


### PR DESCRIPTION
Currently, we are authenticating against bitcoind using user/pass. This adds the option to use a cookie file instead.

Notice providing the two authentication methods at the same time is not permitted, users must set either the user/pass pair or the cookie file path.

Close #246 