### PR TITLE
plugin: patches clippy

### DIFF
--- a/teos/src/tx_index.rs
+++ b/teos/src/tx_index.rs
@@ -276,7 +276,7 @@ mod tests {
 
         // last_n_blocks is ordered from latest to earliest
         let first_block = last_n_blocks.get(cache_size - 1).unwrap();
-        let last_block = last_n_blocks.get(0).unwrap();
+        let last_block = last_n_blocks.first().unwrap();
         let mid = last_n_blocks.get(cache_size / 2).unwrap();
 
         let cache: TxIndex<Locator, Transaction> = TxIndex::new(&last_n_blocks, height as u32);

--- a/teos/src/watcher.rs
+++ b/teos/src/watcher.rs
@@ -1163,7 +1163,7 @@ mod tests {
 
         let mut uuids = HashSet::new();
         // Let the watcher track these breaches.
-        for (_, (_, tx)) in breaches.iter().enumerate() {
+        for tx in breaches.values() {
             let (uuid, appointment) =
                 generate_dummy_appointment_with_user(user_id, Some(&tx.txid()));
             let appointment = appointment.inner;

--- a/watchtower-plugin/src/convert.rs
+++ b/watchtower-plugin/src/convert.rs
@@ -94,6 +94,8 @@ impl RegisterParams {
 impl TryFrom<serde_json::Value> for RegisterParams {
     type Error = RegisterError;
 
+    // clippy-fix: We are getting more than just the first item, so this clippy check does not make sense here
+    #[allow(clippy::get_first)]
     fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
         match value {
             serde_json::Value::String(s) => {
@@ -193,6 +195,8 @@ pub struct GetAppointmentParams {
 impl TryFrom<serde_json::Value> for GetAppointmentParams {
     type Error = GetAppointmentError;
 
+    // clippy-fix: We are getting more than just the first item, so this clippy check does not make sense here
+    #[allow(clippy::get_first)]
     fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
         match value {
             serde_json::Value::Array(a) => {


### PR DESCRIPTION
Clippy is complaining about using `.get(0)` instead of `.fist()` in methods where we are getting more than just the first item. Supress the warning