### PR TITLE
watchtower-plugin: fixes pyln-client version

### DIFF
--- a/watchtower-plugin/tests/pyproject.toml
+++ b/watchtower-plugin/tests/pyproject.toml
@@ -13,6 +13,7 @@ black = "^22.6.0"
 pytest = "^7.1.2"
 pytest-timeout = "^2.1.0"
 pyln-testing = "^0.12.1"
+pyln-client = "^23.11"
 
 
 [build-system]


### PR DESCRIPTION
`pyln-testing` depends on `pyln-client`, and the API for the latter has changed in version 24.0. Fix our dependency to 23.11 to prevent test from breaking.

I'm not really sure why an old version of `pyln-testing` tries to download the newest version of `pyln-client` as dependency, but whatever