### PR TITLE
meta: add possibility to install cln plugin with coffee

### DIFF
--- a/coffee.yml
+++ b/coffee.yml
@@ -1,0 +1,10 @@
+---
+plugin:
+  name: rust-teos
+  version: 0.2.0
+  lang: rust
+  install: |
+    cargo build --release --locked --package watchtower-plugin
+    cp target/release/watchtower-client .
+    cargo clean
+  main: watchtower-client


### PR DESCRIPTION
Core lightning is starting to support a decent plugin manager that gives you the possibility to install a plugin without care about the process.

Coffee [1] is a plugin manager that uses the manifest like all basic plugin managers (npm, pacman ...).

So this commit is adding support for coffee and allowing people to install plugins with the following command:

```
coffee remote add teos-git https://github.com/talaia-labs/rust-teos.git
coffee install rust-teos -v
coffee list
```

[1] https://github.com/coffee-tools/coffee