### PR TITLE
Tower payments pay endpoint: WIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,6 +1291,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "lightning-invoice"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaafc1cebaf9ea8d2a57e60aae9fe6095554b8305714f8452cd8a20a3aa5b7ba"
+dependencies = [
+ "bech32",
+ "bitcoin_hashes",
+ "lightning",
+ "num-traits",
+ "secp256k1",
+]
+
+[[package]]
 name = "lightning-net-tokio"
 version = "0.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,6 +2501,7 @@ dependencies = [
  "jsonrpc-http-server",
  "lightning",
  "lightning-block-sync",
+ "lightning-invoice",
  "lightning-net-tokio",
  "log",
  "prost 0.9.0",

--- a/teos-common/proto/common/teos/v2/user.proto
+++ b/teos-common/proto/common/teos/v2/user.proto
@@ -17,6 +17,19 @@ message RegisterRequest {
     string subscription_signature = 5;
   }
 
+message PayRequest {
+  // Requests an invoice from the tower so that the user can make a payment.
+
+  bytes user_id = 1;
+}
+
+message PayResponse {
+  // Response to a PayRequest containing an invoice for the client to pay.
+
+  bytes user_id = 1;
+  string invoice = 2;
+}
+
   message GetSubscriptionInfoRequest {
     // Request to get a specific user's subscription info.
 

--- a/teos/Cargo.toml
+++ b/teos/Cargo.toml
@@ -37,6 +37,7 @@ torut = "0.2.1"
 bitcoin = { version = "0.28.0", features = [ "base64" ] }
 bitcoincore-rpc = "0.15.0"
 lightning = "0.0.108"
+lightning-invoice = "0.16.0"
 lightning-net-tokio = "0.0.108"
 lightning-block-sync = { version = "0.0.108", features = [ "rpc-client" ] }
 

--- a/teos/proto/teos/v2/tower_services.proto
+++ b/teos/proto/teos/v2/tower_services.proto
@@ -33,6 +33,7 @@ service PublicTowerServices {
   // Public tower services, only reachable from the public API.
 
   rpc register(common.teos.v2.RegisterRequest) returns (common.teos.v2.RegisterResponse) {}
+  rpc pay(common.teos.v2.PayRequest) returns (common.teos.v2.PayResponse) {}
   rpc add_appointment(common.teos.v2.AddAppointmentRequest) returns (common.teos.v2.AddAppointmentResponse) {}
   rpc get_appointment(common.teos.v2.GetAppointmentRequest) returns (common.teos.v2.GetAppointmentResponse) {}
   rpc get_subscription_info(common.teos.v2.GetSubscriptionInfoRequest) returns (common.teos.v2.GetSubscriptionInfoResponse) {}

--- a/teos/src/api/http.rs
+++ b/teos/src/api/http.rs
@@ -687,7 +687,7 @@ mod tests_methods {
     #[tokio::test]
     async fn test_register_max_slots() {
         let (server_addr, _, _s) =
-            run_tower_in_background_with_config(ApiConfig::new(u32::MAX, DURATION)).await;
+            run_tower_in_background_with_config(ApiConfig::new(u32::MAX, DURATION, false)).await;
         let user_id = get_random_user_id();
 
         // Register once, this should go trough and set slots to the limit
@@ -724,7 +724,7 @@ mod tests_methods {
     #[tokio::test]
     async fn test_register_service_unavailable() {
         let (server_addr, _, _s) = run_tower_in_background_with_config(
-            ApiConfig::new(SLOTS, DURATION).bitcoind_unreachable(),
+            ApiConfig::new(SLOTS, DURATION, false).bitcoind_unreachable(),
         )
         .await;
         let user_id = get_random_user_id();
@@ -819,7 +819,7 @@ mod tests_methods {
     async fn test_add_appointment_already_triggered() {
         // Get the InternalAPI so we can mess with the inner state
         let (server_addr, internal_api, _s) =
-            run_tower_in_background_with_config(ApiConfig::new(u32::MAX, DURATION)).await;
+            run_tower_in_background_with_config(ApiConfig::new(u32::MAX, DURATION, false)).await;
 
         // Register
         let (user_sk, user_pk) = cryptography::get_random_keypair();
@@ -870,7 +870,7 @@ mod tests_methods {
     #[tokio::test]
     async fn test_add_appointment_service_unavailable() {
         let (server_addr, _, _s) = run_tower_in_background_with_config(
-            ApiConfig::new(SLOTS, DURATION).bitcoind_unreachable(),
+            ApiConfig::new(SLOTS, DURATION, false).bitcoind_unreachable(),
         )
         .await;
         let (user_sk, _) = cryptography::get_random_keypair();
@@ -1031,7 +1031,7 @@ mod tests_methods {
     #[tokio::test]
     async fn test_get_appointment_service_unavailable() {
         let (server_addr, _, _s) = run_tower_in_background_with_config(
-            ApiConfig::new(SLOTS, DURATION).bitcoind_unreachable(),
+            ApiConfig::new(SLOTS, DURATION, false).bitcoind_unreachable(),
         )
         .await;
 
@@ -1130,7 +1130,7 @@ mod tests_methods {
     async fn test_get_subscription_info_service_unavailable() {
         let (user_sk, _) = cryptography::get_random_keypair();
         let (server_addr, _, _s) = run_tower_in_background_with_config(
-            ApiConfig::new(SLOTS, DURATION).bitcoind_unreachable(),
+            ApiConfig::new(SLOTS, DURATION, false).bitcoind_unreachable(),
         )
         .await;
 

--- a/teos/src/dbm.rs
+++ b/teos/src/dbm.rs
@@ -878,7 +878,7 @@ mod tests {
                 SUBSCRIPTION_START + i,
                 SUBSCRIPTION_EXPIRY + i,
             );
-            users.insert(user_id, user);
+            users.insert(user_id, user.clone());
             dbm.store_user(user_id, &user).unwrap();
         }
 
@@ -1251,7 +1251,7 @@ mod tests {
             // When the appointment are deleted, the user will get back slots based on the deleted data.
             // Here we can just make a number up to make sure it matches.
             user.available_slots = i as u32;
-            let updated_users = HashMap::from_iter([(user_id, user)]);
+            let updated_users = HashMap::from_iter([(user_id, user.clone())]);
 
             // Check that the db transaction had i queries on it
             assert_eq!(
@@ -1286,7 +1286,10 @@ mod tests {
             Ok { .. }
         ));
 
-        dbm.batch_remove_appointments(&[uuid], &HashMap::from_iter([(appointment.user_id, info)]));
+        dbm.batch_remove_appointments(
+            &[uuid],
+            &HashMap::from_iter([(appointment.user_id, info.clone())]),
+        );
         assert!(dbm.load_appointment(uuid).is_none());
 
         // Appointment + Tracker

--- a/teos/src/fees.rs
+++ b/teos/src/fees.rs
@@ -1,0 +1,17 @@
+use core::fmt::Debug;
+use lightning_invoice::Invoice;
+
+/// This trait specifies the functionality that needs to be implemented to
+/// accept and validate a payment from a user.
+pub trait ValidatePayment {
+    // Generates an invoice for the user to pay.
+    fn get_invoice(&self) -> Invoice;
+    // Validates that the payment was paid.
+    fn validate(&self, invoice: Invoice) -> bool;
+}
+
+impl Debug for dyn ValidatePayment + std::marker::Send + 'static {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "hello")
+    }
+}

--- a/teos/src/gatekeeper.rs
+++ b/teos/src/gatekeeper.rs
@@ -15,7 +15,7 @@ use crate::dbm::DBM;
 use crate::extended_appointment::{ExtendedAppointment, UUID};
 
 /// Data regarding a user subscription with the tower.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct UserInfo {
     /// Number of appointment slots available for a given user.
     pub(crate) available_slots: u32,
@@ -273,7 +273,7 @@ impl Gatekeeper {
                 let (user_id, blob_size) = dbm.get_appointment_user_and_length(*uuid).unwrap();
                 registered_users.get_mut(&user_id).unwrap().available_slots +=
                     compute_appointment_slots(blob_size, ENCRYPTED_BLOB_MAX_SIZE);
-                updated_users.insert(user_id, registered_users[&user_id]);
+                updated_users.insert(user_id, registered_users[&user_id].clone());
             }
             updated_users
         } else {

--- a/teos/src/gatekeeper.rs
+++ b/teos/src/gatekeeper.rs
@@ -14,6 +14,7 @@ use teos_common::UserId;
 
 use crate::dbm::DBM;
 use crate::extended_appointment::{ExtendedAppointment, UUID};
+use crate::fees::ValidatePayment;
 
 /// Data regarding a user subscription with the tower.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -60,6 +61,21 @@ pub(crate) struct NotEnoughSlots;
 #[derive(Debug, PartialEq)]
 pub(crate) struct MaxSlotsReached;
 
+/// Error raised if a user is trying to pay the tower, but the tower isn't accepting payments.
+#[derive(Debug, PartialEq)]
+pub(crate) struct PaymentsNotAccepted;
+
+// Errors encountered when using the add_update_user command.
+#[derive(Debug)]
+pub enum UpdateUserError {
+    // Error raised if the user subscription slots limit has been reached.
+    MaxSlotsReached,
+    // Error raised if a user is trying to pay the tower, but the tower isn't accepting payments.
+    PaymentsNotAccepted,
+    // User is trying to register with the tower, but they haven't paid an invoice yet.
+    UnpaidInvoice
+}
+
 /// Component in charge of managing access to the tower resources.
 ///
 /// The [Gatekeeper] keeps track of user subscriptions and allow users to interact with the tower based on it.
@@ -81,6 +97,8 @@ pub struct Gatekeeper {
     registered_users: Mutex<HashMap<UserId, UserInfo>>,
     /// A [DBM] (database manager) instance. Used to persist appointment data into disk.
     dbm: Arc<Mutex<DBM>>,
+    /// If fee mode is on, this validates payments made to the watchtower.
+    validator: Option<Arc<Mutex<dyn ValidatePayment + Send>>>,
 }
 
 impl Gatekeeper {
@@ -91,6 +109,7 @@ impl Gatekeeper {
         subscription_duration: u32,
         expiry_delta: u32,
         dbm: Arc<Mutex<DBM>>,
+        validator: Option<Arc<Mutex<dyn ValidatePayment + Send>>>,
     ) -> Self {
         let registered_users = dbm.lock().unwrap().load_all_users();
         Gatekeeper {
@@ -100,6 +119,7 @@ impl Gatekeeper {
             expiry_delta,
             registered_users: Mutex::new(registered_users),
             dbm,
+            validator,
         }
     }
 
@@ -154,7 +174,7 @@ impl Gatekeeper {
     pub(crate) fn add_update_user(
         &self,
         user_id: UserId,
-    ) -> Result<RegistrationReceipt, MaxSlotsReached> {
+    ) -> Result<RegistrationReceipt, UpdateUserError> {
         let block_count = self.last_known_block_height.load(Ordering::Acquire);
 
         // TODO: For now, new calls to `add_update_user` add subscription_slots to the current count and reset the expiry time
@@ -162,31 +182,39 @@ impl Gatekeeper {
         let user_info = match registered_users.get_mut(&user_id) {
             // User already exists, updating the info
             Some(user_info) => {
-                user_info.available_slots = user_info
-                    .available_slots
-                    .checked_add(self.subscription_slots)
-                    .ok_or(MaxSlotsReached)?;
-                user_info.subscription_expiry = user_info
-                    .subscription_expiry
-                    .checked_add(self.subscription_duration)
-                    .unwrap_or(u32::MAX);
-                self.dbm.lock().unwrap().update_user(user_id, user_info);
-
-                user_info
+                if let Some(validator) = &self.validator {
+                    match &user_info.invoice {
+                        Some(invoice) => {
+                            let paid = validator.lock().unwrap().validate(invoice.clone());
+                            if paid {
+                                self.add_slots_to_user(user_id, user_info)?;
+                                user_info
+                            } else {
+                                return Err(UpdateUserError::UnpaidInvoice)
+                            }
+                        },
+                        None => {
+                            return Err(UpdateUserError::UnpaidInvoice)
+                        }
+                    }
+                } else {
+                    self.add_slots_to_user(user_id, user_info)?;
+                    user_info
+                }
             }
             // New user
             None => {
-                let user_info = UserInfo::new(
+                if let Some(_) = &self.validator {
+                    return Err(UpdateUserError::UnpaidInvoice)
+                }
+
+                let user_info = self.add_new_user(
+                    user_id,
                     self.subscription_slots,
                     block_count,
                     block_count + self.subscription_duration,
                     None,
                 );
-                self.dbm
-                    .lock()
-                    .unwrap()
-                    .store_user(user_id, &user_info)
-                    .unwrap();
 
                 registered_users.insert(user_id, user_info);
                 registered_users.get_mut(&user_id).unwrap()
@@ -199,6 +227,89 @@ impl Gatekeeper {
             user_info.subscription_start,
             user_info.subscription_expiry,
         ))
+    }
+
+    pub(crate) fn add_new_user(
+        &self,
+        user_id: UserId,
+        available_slots: u32,
+        subscription_start: u32,
+        subscription_expiry: u32,
+        invoice: Option<Invoice>,
+    ) -> UserInfo {
+        let user_info = UserInfo::new(
+            available_slots,
+            subscription_start,
+            subscription_expiry,
+            invoice,
+        );
+
+        self.dbm
+            .lock()
+            .unwrap()
+            .store_user(user_id, &user_info)
+            .unwrap();
+
+        user_info
+    }
+
+    pub(crate) fn add_update_invoice(
+        &self,
+        user_id: UserId,
+    ) -> Result<Invoice, PaymentsNotAccepted> {
+        let mut registered_users = self.registered_users.lock().unwrap();
+        match registered_users.get_mut(&user_id) {
+            Some(user_info) => {
+                match &user_info.invoice {
+                    Some(invoice) => {
+                        // If the current invoice on file isn't expired, we'll send it back to the user.
+                        // Otherwise, we'll generate a new one.
+                        if invoice.is_expired() {
+                            if let Some(validator) = &self.validator {
+                                Ok(validator.lock().unwrap().get_invoice())
+                            } else {
+                                Err(PaymentsNotAccepted)
+                            }
+                        } else {
+                            Ok(invoice.clone())
+                        }
+                    }
+                    None => {
+                        if let Some(validator) = &self.validator {
+                            Ok(validator.lock().unwrap().get_invoice())
+                        } else {
+                            Err(PaymentsNotAccepted)
+                        }
+                    }
+                }
+            }
+            None => {
+                let invoice = if let Some(validator) = &self.validator {
+                    validator.lock().unwrap().get_invoice()
+                } else {
+                    return Err(PaymentsNotAccepted);
+                };
+                let user_info = self.add_new_user(user_id, 0, 0, 0, Some(invoice.clone()));
+                registered_users.insert(user_id, user_info);
+
+                Ok(invoice)
+            }
+        }
+    }
+
+    pub(crate) fn add_slots_to_user(&self, user_id: UserId, user_info: &mut UserInfo) -> Result<(), UpdateUserError> {
+        user_info.available_slots = user_info
+            .available_slots
+            .checked_add(self.subscription_slots)
+            .ok_or(UpdateUserError::MaxSlotsReached)?;
+        
+        user_info.subscription_expiry = user_info
+            .subscription_expiry
+            .checked_add(self.subscription_duration)
+            .unwrap_or(u32::MAX);
+        self.dbm.lock().unwrap().update_user(user_id, user_info);
+
+        Ok(())
     }
 
     /// Adds an appointment to a given user, or updates it if already present in the system (and belonging to the requester).
@@ -386,7 +497,14 @@ mod tests {
 
     fn init_gatekeeper(chain: &Blockchain) -> Gatekeeper {
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
-        Gatekeeper::new(chain.get_block_count(), SLOTS, DURATION, EXPIRY_DELTA, dbm)
+        Gatekeeper::new(
+            chain.get_block_count(),
+            SLOTS,
+            DURATION,
+            EXPIRY_DELTA,
+            dbm,
+            None,
+        )
     }
 
     #[test]
@@ -401,6 +519,7 @@ mod tests {
             DURATION,
             EXPIRY_DELTA,
             dbm.clone(),
+            None,
         );
         assert!(gatekeeper.is_fresh());
 
@@ -424,8 +543,14 @@ mod tests {
         }
 
         // Create a new GK reusing the same DB and check that the data is loaded
-        let another_gk =
-            Gatekeeper::new(chain.get_block_count(), SLOTS, DURATION, EXPIRY_DELTA, dbm);
+        let another_gk = Gatekeeper::new(
+            chain.get_block_count(),
+            SLOTS,
+            DURATION,
+            EXPIRY_DELTA,
+            dbm,
+            None,
+        );
         assert!(!another_gk.is_fresh());
         assert_eq!(gatekeeper, another_gk);
     }
@@ -518,7 +643,7 @@ mod tests {
 
         assert!(matches!(
             gatekeeper.add_update_user(user_id),
-            Err(MaxSlotsReached)
+            Err(UpdateUserError::MaxSlotsReached)
         ));
 
         // Data in the database remains untouched

--- a/teos/src/lib.rs
+++ b/teos/src/lib.rs
@@ -17,6 +17,7 @@ pub mod dbm;
 #[doc(hidden)]
 mod errors;
 mod extended_appointment;
+mod fees;
 pub mod gatekeeper;
 pub mod responder;
 #[doc(hidden)]

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -273,6 +273,7 @@ async fn main() {
         conf.subscription_duration,
         conf.expiry_delta,
         dbm.clone(),
+        None,
     ));
 
     let mut poller = ChainPoller::new(&mut derefed, Network::from_str(btc_network).unwrap());
@@ -369,6 +370,7 @@ async fn main() {
         addresses,
         bitcoind_reachable.clone(),
         shutdown_trigger,
+        None,
     ));
     let internal_api_cloned = internal_api.clone();
 

--- a/teos/src/responder.rs
+++ b/teos/src/responder.rs
@@ -580,6 +580,7 @@ mod tests {
             DURATION,
             EXPIRY_DELTA,
             dbm.clone(),
+            None,
         );
         create_responder(chain, Arc::new(gk), dbm, mocked_query).await
     }


### PR DESCRIPTION
This PR begins to add payment support to TEOS. I'm realizing I have a lot of thoughts and the project is a bit bigger than I expected. So figured I'd try to see if I can get a little feedback on the approach I'm taking before I get too far along. 🤞🏻 

**Approach so far**:

I've started by creating a new "pay" endpoint. This will be used to grab an invoice to pay when a user needs to register or top up their account (maybe a more accurate name would just be "get_invoice" to then pay after).

The steps for a user to make a payment (for initial registration or for a top up) are:
- Hit "pay" endpoint to grab an invoice.
- Pay the invoice.
- Hit "register" endpoint, where the tower will validate that the user actually paid the invoice and the user will receive the receipt for registration.

On the tower side, once a user hits the pay endpoint for the first time, the tower associates the user's provided uuid with the invoice, and stores it in memory and in the db. IMO the advantages of "one-invoice-per-user" model are that:
- The user won't waste resources if they hit the "pay" endpoint a million times. Instead of needing to generate a new invoice for every call (clutting the tower's lightning node db and making it harder to look through listinvoices to see if a payment is indeed paid), the tower will just return the invoice the user hadn't yet paid earlier.
- A nice side effect I guess is the user won't have to provide any sort of proof of payment to the tower. The tower will just know if the user has paid their associated invoice or not. 

**Future stuff: This will come in future PRs**

The above all takes the endpoint logic into account. After that, we'll need to build some other things:
- Validator - As @sr-gi and I had talked about earlier, the validator is for now behind a trait so that any lightning implementation can eventually be used to generate invoices/verify payments. At some point we'll need to implement one option (perhaps starting with CLN?) to actually allow payments.
- Once the pieces above are in place, we'll add config options, allowing the watchtower to turn on required payments & specify the payment amount they require for how many subscription slots, etc.
- Add the ability to make these payments in watchtower-plugin. (And perhaps some integration tests to make sure everything is working together correctly?)