### PR TITLE
modernize cln tests and CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,10 @@
 name: Continuous Integration Checks
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/cln-plugin.yaml
+++ b/.github/workflows/cln-plugin.yaml
@@ -1,10 +1,14 @@
 name: CI tests for CLN watchtower-plugin
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 
 env:
-  bitcoind_version: 0.20.1
-  cln_version: 0.12.1
+  bitcoind_version: "27.0"
+  cln_version: "24.02.2"
 
 jobs:
   cache-cln:
@@ -28,10 +32,10 @@ jobs:
           PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         if: ${{ steps.cache-cln.outputs.cache-hit != 'true' }}
         run: |
-          sudo apt-get update && sudo apt-get install gettext
+          sudo apt-get update && sudo apt-get install -y gettext protobuf-compiler
           git clone https://github.com/ElementsProject/lightning.git && cd lightning && git checkout v${{ env.cln_version }}
           pip install --user poetry && poetry install
-          ./configure --enable-developer && poetry run make
+          ./configure && poetry run make
 
   cln-plugin:
     needs: cache-cln
@@ -69,4 +73,4 @@ jobs:
       - name: Run tests
         run: |
           cd watchtower-plugin/tests
-          DEVELOPER=1 SLOW_MACHINE=1 poetry run pytest test.py --log-cli-level=INFO -s
+          VALGRIND=0 SLOW_MACHINE=1 poetry run pytest test.py --log-cli-level=INFO -s

--- a/watchtower-plugin/src/retrier.rs
+++ b/watchtower-plugin/src/retrier.rs
@@ -103,7 +103,7 @@ impl RetryManager {
                     } else if let Some(retrier) = self.retriers.get(&tower_id) {
                         if retrier.is_idle() {
                             if !data.is_none() {
-                                log::error!("Data was send to an idle retier. This should have never happened. Please report! ({data:?})");
+                                log::error!("Data was send to an idle retrier. This should have never happened. Please report! ({data:?})");
                                 continue;
                             }
                             log::info!(
@@ -774,7 +774,7 @@ mod tests {
             .unwrap()
             .is_running());
 
-        // Wait until the task gives up and check again (this gives up due to accumulation of transient errors, so the retiers will be idle).
+        // Wait until the task gives up and check again (this gives up due to accumulation of transient errors, so the retriers will be idle).
         wait_until!(wt_client
             .lock()
             .unwrap()

--- a/watchtower-plugin/tests/conftest.py
+++ b/watchtower-plugin/tests/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import subprocess
 
 from pyln.testing.fixtures import *  # noqa: F401,F403
-from pyln.testing.utils import DEVELOPER, BITCOIND_CONFIG, TailableProc
+from pyln.testing.utils import BITCOIND_CONFIG, TailableProc
 
 WT_PLUGIN = Path("~/.cargo/bin/watchtower-client").expanduser()
 TEOSD_CONFIG = {
@@ -114,19 +114,6 @@ def pytest_runtest_makereport(item, call):
     # be "setup", "call", "teardown"
 
     setattr(item, "rep_" + rep.when, rep)
-
-
-def pytest_configure(config):
-    config.addinivalue_line("markers", "developer: only run when developer is flagged on")
-
-
-def pytest_runtest_setup(item):
-    for mark in item.iter_markers(name="developer"):
-        if not DEVELOPER:
-            if len(mark.args):
-                pytest.skip("!DEVELOPER: {}".format(mark.args[0]))
-            else:
-                pytest.skip("!DEVELOPER: Requires DEVELOPER=1")
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/watchtower-plugin/tests/pyproject.toml
+++ b/watchtower-plugin/tests/pyproject.toml
@@ -12,8 +12,8 @@ black = "^22.6.0"
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
 pytest-timeout = "^2.1.0"
-pyln-testing = "^0.12.1"
-pyln-client = "^23.11"
+pyln-testing = "^24.2.1"
+pyln-client = "^24.2.1"
 
 
 [build-system]


### PR DESCRIPTION
Replaces #255 

I think in your PR tests ran slow because you were running them on an ancient pyln-testing version. Just to make sure i added VALGRIND=0 as that can cause huge slowdowns but i don't know when valgrind actually runs in these tests.

I also assume you don't want CI to run on anything else than commit to the master branch. While testing with a PR all CI ran both for the feature branch and the PR kinda weird.

Also `developer: None` is not needed with a modern `pyln-testing` version, as that is a default setting.