### PR TITLE
CI: add release workflow for building binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Build and release
+on:
+    push:
+      tags:
+        - 'v[0-9]+\.[0-9]+\.[0-9]+'
+
+jobs:
+    build:
+        name: build release binaries
+        runs-on: "ubuntu-latest"
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Install rust
+              id: rust
+              uses: dtolnay/rust-toolchain@stable
+
+            - name: Install cross
+              run: |
+                cargo install cross --git https://github.com/cross-rs/cross
+
+            - name: Build unix
+              id: unix_build
+              run: |
+                cross build --release --locked --target x86_64-unknown-linux-gnu
+                cross build --release --locked --target armv7-unknown-linux-gnueabihf
+                cross build --release --locked --target aarch64-unknown-linux-gnu
+
+            - name: Package unix binaries
+              run: |
+                tar -czf "teos-${{github.ref_name}}-aarch64-linux.tar.gz" --transform 's|.*/||' "target/aarch64-unknown-linux-gnu/release/teosd" "target/aarch64-unknown-linux-gnu/release/teos-cli"
+                tar -czf "teos-${{github.ref_name}}-armv7-linux.tar.gz" --transform 's|.*/||' "target/armv7-unknown-linux-gnueabihf/release/teosd" "target/armv7-unknown-linux-gnueabihf/release/teos-cli"
+                tar -czf "teos-${{github.ref_name}}-x86_64-linux.tar.gz" --transform 's|.*/||' "target/x86_64-unknown-linux-gnu/release/teosd" "target/x86_64-unknown-linux-gnu/release/teos-cli"
+                tar -czf "watchtower-client-${{github.ref_name}}-aarch64-linux.tar.gz" --transform 's|.*/||' "target/aarch64-unknown-linux-gnu/release/watchtower-client"
+                tar -czf "watchtower-client-${{github.ref_name}}-armv7-linux.tar.gz" --transform 's|.*/||' "target/armv7-unknown-linux-gnueabihf/release/watchtower-client"
+                tar -czf "watchtower-client-${{github.ref_name}}-x86_64-linux.tar.gz" --transform 's|.*/||' "target/x86_64-unknown-linux-gnu/release/watchtower-client"
+
+            - name: Upload unix artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                name: unix-binaries
+                path: |
+                  *.tar.gz
+
+            - name: Get rust version
+              id: rversion
+              run: |
+                echo "rust_version=$(rustc --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+        outputs:
+            rust-version: ${{ steps.rversion.outputs.rust_version }}
+
+    release:
+        name: Github Release
+        needs: [build]
+        runs-on: "ubuntu-latest"
+        permissions:
+            contents: write
+        steps:
+            - name: Get semver version from tag
+              id: tag_name
+              run: echo "current_version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            # - name: Get Changelog Entry
+            #   id: changelog_reader
+            #   uses: mindsers/changelog-reader-action@v2
+            #   with:
+            #     version: ${{ steps.tag_name.outputs.current_version }}
+            #     path: ./CHANGELOG.md
+
+            # - name: Get tag message
+            #   id: get_tag_message
+            #   run: |
+            #     TAG_NAME=$(echo "${GITHUB_REF}" | sed 's/refs\/tags\///')
+            #     TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG_NAME}")
+            #     echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+            #     echo "tag_message=${TAG_MESSAGE}" >> "$GITHUB_OUTPUT"
+
+            - name: Download Artifacts
+              uses: actions/download-artifact@v4
+              with:
+                merge-multiple: true
+
+            - name: Release
+              uses: ncipollo/release-action@v1
+              with:
+                allowUpdates: false
+                artifactErrorsFailBuild: true
+                # body: "${{ steps.changelog_reader.outputs.changes }} \n\n### Release binaries info\n\n- Release binaries were built using rust ${{ needs.build.outputs.rust-version }}\n- Linux release binaries require glibc>=2.31"
+                # body: "${{ steps.get_tag_message.outputs.tag_message }} \n\n### Release binaries info\n\n- Release binaries were built using rust ${{ needs.build.outputs.rust-version }}\n- Linux release binaries require glibc>=2.31"
+                body: "### Release binaries info\n\n- Release binaries were built using rust ${{ needs.build.outputs.rust-version }}\n- Linux release binaries require glibc>=2.31"
+                artifacts: |
+                  *.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,22 +381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,21 +607,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1047,6 +1016,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper 0.14.18",
+ "rustls 0.20.9",
+ "tokio 1.25.0",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,19 +1038,6 @@ dependencies = [
  "pin-project-lite 0.2.8",
  "tokio 1.25.0",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes 1.1.0",
- "hyper 0.14.18",
- "native-tls",
- "tokio 1.25.0",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -1449,24 +1418,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "native-tls"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "net2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,51 +1507,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -2025,26 +1931,28 @@ dependencies = [
  "http",
  "http-body 0.4.4",
  "hyper 0.14.18",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.8",
+ "rustls 0.20.9",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.25.0",
- "tokio-native-tls",
+ "tokio-rustls 0.23.4",
  "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2125,8 +2033,20 @@ dependencies = [
  "base64 0.13.0",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.2",
 ]
 
 [[package]]
@@ -2143,16 +2063,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "schannel"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
-dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
-]
 
 [[package]]
 name = "scoped-tls"
@@ -2177,6 +2087,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "secp256k1"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,29 +2113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2658,24 +2555,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio 1.25.0",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio 1.25.0",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.9",
+ "tokio 1.25.0",
+ "webpki 0.22.2",
 ]
 
 [[package]]
@@ -2786,7 +2684,7 @@ dependencies = [
  "prost 0.8.0",
  "prost-derive 0.8.0",
  "tokio 1.25.0",
- "tokio-rustls",
+ "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-util 0.6.9",
  "tower",
@@ -2818,7 +2716,7 @@ dependencies = [
  "prost 0.9.0",
  "prost-derive 0.9.0",
  "tokio 1.25.0",
- "tokio-rustls",
+ "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-util 0.6.9",
  "tower",
@@ -3236,6 +3134,25 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki 0.22.2",
 ]
 
 [[package]]

--- a/watchtower-plugin/Cargo.toml
+++ b/watchtower-plugin/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 backoff = { version = "0.4.0", features = ["tokio"] }
 hex = { version = "0.4.3", features = [ "serde" ] }
 home = "0.5.3"
-reqwest = { version = "0.11", features = [ "blocking", "json", "socks" ] }
+reqwest = { version = "0.11", default-features = false, features = [ "blocking", "json", "socks", "rustls-tls" ] }
 log = "0.4.16"
 rusqlite = { version = "0.26.0", features = [ "bundled", "limits" ] }
 serde = "1.0.130"


### PR DESCRIPTION
This PR adds a workflow to create a release with release binaries.

It cross compiles for:

- `x86_64-unknown-linux-gnu`
- `aarch64-unknown-linux-gnu`
- `armv7-unknown-linux-gnueabihf`

using [cross](https://github.com/cross-rs/cross) and only requires glibc >= 2.31.

I packaged `teosd` and `teos-cli` together while `watchtower-client` is in an extra archive.

For better cross compatibility i removed the dependency to the system specific `openssl` and replaced it with `rustls-tls`.

For this job to trigger you have to push an **_annotated_** tag. It will only trigger on tags that represent final releases.

This project does not have a CHANGELOG.md so i commented in two methods on how to provide the content body for the release:

- either create a CHANGELOG.md that adheres to the formatting of [keepachangelog](https://keepachangelog.com/en/1.1.0/)
- or use the message from the annotated tag (can also be a file with -F)

You can of course also just edit the release body manually on the website but then it won't show in the notification email that is send to users.