### PR TITLE
refactor(tests): Hide bitcoind stopper

### DIFF
--- a/teos/src/api/internal.rs
+++ b/teos/src/api/internal.rs
@@ -446,7 +446,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_all_appointments() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         let response = internal_api
             .get_all_appointments(Request::new(()))
@@ -459,7 +459,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_all_appointments_watcher() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // Add data to the Watcher so we can retrieve it later on
         let (user_sk, user_pk) = get_random_keypair();
@@ -487,7 +487,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_all_appointments_responder() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // Add data to the Responser so we can retrieve it later on
         internal_api.watcher.add_random_tracker_to_responder();
@@ -507,7 +507,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_appointments() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         let locator = Locator::new(get_random_tx().txid()).to_vec();
         let response = internal_api
@@ -521,7 +521,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_appointments_watcher() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         for i in 0..3 {
             // Create a dispute tx to be used for creating different dummy appointments with the same locator.
@@ -571,7 +571,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_appointments_responder() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         for i in 0..3 {
             // Create a dispute tx to be used for creating different trackers.
@@ -622,7 +622,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_tower_info_empty() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         let response = internal_api
             .get_tower_info(Request::new(()))
@@ -638,7 +638,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_tower_info() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // Register a user
         let (user_sk, user_pk) = get_random_keypair();
@@ -675,7 +675,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_users() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
         let mut users = HashSet::new();
 
         // Add a couple of users
@@ -697,7 +697,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_users_empty() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         let response = internal_api
             .get_users(Request::new(()))
@@ -710,7 +710,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_user() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // Register a user and get it back
         let (user_sk, user_pk) = get_random_keypair();
@@ -752,7 +752,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_get_user_not_found() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // Non-registered user
         let (_, user_pk) = get_random_keypair();
@@ -773,7 +773,7 @@ mod tests_private_api {
 
     #[tokio::test]
     async fn test_stop() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         assert!(!internal_api.shutdown_trigger.is_triggered());
         internal_api.stop(Request::new(())).await.unwrap();
@@ -795,7 +795,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_register() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         let (_, user_pk) = get_random_keypair();
 
@@ -815,7 +815,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_register_wrong_user_id() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         let mut user_ids = Vec::new();
 
@@ -846,7 +846,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_register_max_slots() {
-        let (internal_api, _s) = create_api_with_config(ApiConfig::new(u32::MAX, DURATION)).await;
+        let internal_api = create_api_with_config(ApiConfig::new(u32::MAX, DURATION)).await;
 
         let (_, user_pk) = get_random_keypair();
         let user_id = UserId(user_pk).to_vec();
@@ -874,7 +874,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_register_service_unavailable() {
-        let (internal_api, _s) =
+        let internal_api =
             create_api_with_config(ApiConfig::new(u32::MAX, DURATION).bitcoind_unreachable()).await;
 
         let (_, user_pk) = get_random_keypair();
@@ -894,7 +894,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // User must be registered
         let (user_sk, user_pk) = get_random_keypair();
@@ -920,7 +920,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment_non_registered() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // User is not registered this time
         let (user_sk, _) = get_random_keypair();
@@ -948,7 +948,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment_not_enough_slots() {
-        let (internal_api, _s) = create_api_with_config(ApiConfig::new(0, DURATION)).await;
+        let internal_api = create_api_with_config(ApiConfig::new(0, DURATION)).await;
 
         // User is registered but has no slots
         let (user_sk, user_pk) = get_random_keypair();
@@ -977,7 +977,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment_subscription_expired() {
-        let (internal_api, _s) = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
+        let internal_api = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
 
         // User is registered but subscription is expired
         let (user_sk, user_pk) = get_random_keypair();
@@ -1003,7 +1003,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment_already_triggered() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         let (user_sk, user_pk) = get_random_keypair();
         let user_id = UserId(user_pk);
@@ -1042,7 +1042,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_add_appointment_service_unavailable() {
-        let (internal_api, _s) =
+        let internal_api =
             create_api_with_config(ApiConfig::new(u32::MAX, DURATION).bitcoind_unreachable()).await;
 
         let (user_sk, _) = get_random_keypair();
@@ -1066,7 +1066,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_appointment() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // The user must be registered
         let (user_sk, user_pk) = get_random_keypair();
@@ -1099,7 +1099,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_appointment_non_registered() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // Add a first user to link the appointment to him
         let (user_sk, user_pk) = get_random_keypair();
@@ -1127,7 +1127,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_appointment_non_existent() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // The user is registered but the appointment does not exist
         let (user_sk, user_pk) = get_random_keypair();
@@ -1154,7 +1154,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_appointment_subscription_expired() {
-        let (internal_api, _s) = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
+        let internal_api = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
 
         // Register the user
         let (user_sk, user_pk) = get_random_keypair();
@@ -1182,7 +1182,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_appointment_service_unavailable() {
-        let (internal_api, _s) =
+        let internal_api =
             create_api_with_config(ApiConfig::new(SLOTS, DURATION).bitcoind_unreachable()).await;
 
         let (user_sk, _) = get_random_keypair();
@@ -1205,7 +1205,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_subscription_info() {
-        let (internal_api, _s) = create_api().await;
+        let internal_api = create_api().await;
 
         // The user must be registered
         let (user_sk, user_pk) = get_random_keypair();
@@ -1229,7 +1229,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_subscription_info_non_registered() {
-        let (internal_api, _s) = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
+        let internal_api = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
 
         // The user is not registered
         let (user_sk, _) = get_random_keypair();
@@ -1252,7 +1252,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_subscription_info_expired() {
-        let (internal_api, _s) = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
+        let internal_api = create_api_with_config(ApiConfig::new(SLOTS, 0)).await;
 
         // The user is registered but the subscription has expired
         let (user_sk, user_pk) = get_random_keypair();
@@ -1276,7 +1276,7 @@ mod tests_public_api {
 
     #[tokio::test]
     async fn test_get_subscription_info_service_unavailable() {
-        let (internal_api, _s) =
+        let internal_api =
             create_api_with_config(ApiConfig::new(SLOTS, DURATION).bitcoind_unreachable()).await;
 
         let (user_sk, _) = get_random_keypair();

--- a/teos/src/carrier.rs
+++ b/teos/src/carrier.rs
@@ -26,7 +26,7 @@ pub struct Carrier {
     block_height: u32,
     #[cfg(test)]
     /// A stopper that stops the mock bitcoind server in tests when the [`Carrier`] is dropped.
-    _stopper: Option<crate::test_utils::BitcoindStopper>,
+    _stopper: crate::test_utils::BitcoindStopper,
 }
 
 impl Carrier {
@@ -35,7 +35,7 @@ impl Carrier {
         bitcoin_cli: Arc<BitcoindClient>,
         bitcoind_reachable: Arc<(Mutex<bool>, Condvar)>,
         last_known_block_height: u32,
-        #[cfg(test)] stopper: Option<crate::test_utils::BitcoindStopper>,
+        #[cfg(test)] stopper: crate::test_utils::BitcoindStopper,
     ) -> Self {
         Carrier {
             bitcoin_cli,
@@ -218,7 +218,12 @@ mod tests {
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
 
-        let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let mut carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
 
         // Lets add some dummy data into the cache
         for i in 0..10 {
@@ -242,7 +247,12 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock.server);
 
-        let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let mut carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
@@ -260,7 +270,12 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock.server);
 
-        let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let mut carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
@@ -280,7 +295,12 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock.server);
 
-        let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let mut carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
@@ -302,7 +322,12 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock.server);
 
-        let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let mut carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
@@ -325,7 +350,12 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock.server);
 
-        let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let mut carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
@@ -344,7 +374,12 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock.server);
 
-        let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let mut carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let r = carrier.send_transaction(&tx);
 
@@ -364,7 +399,12 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(false), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        let mut carrier = Carrier::new(bitcoin_cli, bitcoind_reachable.clone(), start_height, None);
+        let mut carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable.clone(),
+            start_height,
+            bitcoind_mock.stopper,
+        );
 
         let tx = consensus::deserialize(&Vec::from_hex(TX_HEX).unwrap()).unwrap();
         let delay = std::time::Duration::new(3, 0);
@@ -394,7 +434,12 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock.server);
 
-        let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
         let txid = Txid::from_hex(TXID_HEX).unwrap();
         assert!(carrier.in_mempool(&txid));
     }
@@ -407,7 +452,12 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock.server);
 
-        let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
         let txid = Txid::from_hex(TXID_HEX).unwrap();
         assert!(!carrier.in_mempool(&txid));
     }
@@ -422,7 +472,12 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock.server);
 
-        let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
         let txid = Txid::from_hex(TXID_HEX).unwrap();
         assert!(!carrier.in_mempool(&txid));
     }
@@ -436,7 +491,12 @@ mod tests {
         let start_height = START_HEIGHT as u32;
         start_server(bitcoind_mock.server);
 
-        let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, start_height, None);
+        let carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable,
+            start_height,
+            bitcoind_mock.stopper,
+        );
         let txid = Txid::from_hex(TXID_HEX).unwrap();
         assert!(!carrier.in_mempool(&txid));
     }
@@ -448,7 +508,12 @@ mod tests {
         let bitcoind_reachable = Arc::new((Mutex::new(false), Condvar::new()));
         let bitcoin_cli = Arc::new(BitcoindClient::new(bitcoind_mock.url(), Auth::None).unwrap());
         let start_height = START_HEIGHT as u32;
-        let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable.clone(), start_height, None);
+        let carrier = Carrier::new(
+            bitcoin_cli,
+            bitcoind_reachable.clone(),
+            start_height,
+            bitcoind_mock.stopper,
+        );
 
         let txid = Txid::from_hex(TXID_HEX).unwrap();
         let delay = std::time::Duration::new(3, 0);

--- a/teos/src/carrier.rs
+++ b/teos/src/carrier.rs
@@ -31,33 +31,18 @@ pub struct Carrier {
 
 impl Carrier {
     /// Creates a new [Carrier] instance.
-    #[cfg(not(test))]
     pub fn new(
         bitcoin_cli: Arc<BitcoindClient>,
         bitcoind_reachable: Arc<(Mutex<bool>, Condvar)>,
         last_known_block_height: u32,
+        #[cfg(test)] stopper: Option<crate::test_utils::BitcoindStopper>,
     ) -> Self {
         Carrier {
             bitcoin_cli,
             bitcoind_reachable,
             issued_receipts: HashMap::new(),
             block_height: last_known_block_height,
-        }
-    }
-
-    /// Creates a new [Carrier] instance.
-    #[cfg(test)]
-    pub fn new(
-        bitcoin_cli: Arc<BitcoindClient>,
-        bitcoind_reachable: Arc<(Mutex<bool>, Condvar)>,
-        last_known_block_height: u32,
-        stopper: Option<crate::test_utils::BitcoindStopper>,
-    ) -> Self {
-        Carrier {
-            bitcoin_cli,
-            bitcoind_reachable,
-            issued_receipts: HashMap::new(),
-            block_height: last_known_block_height,
+            #[cfg(test)]
             _stopper: stopper,
         }
     }

--- a/teos/src/responder.rs
+++ b/teos/src/responder.rs
@@ -479,13 +479,12 @@ mod tests {
     use crate::dbm::DBM;
     use crate::rpc_errors;
     use crate::test_utils::{
-        create_carrier, generate_dummy_appointment, generate_dummy_appointment_with_user,
-        generate_uuid, get_last_n_blocks, get_random_breach, get_random_tracker, get_random_tx,
-        store_appointment_and_its_user, Blockchain, MockedServerQuery, DURATION, EXPIRY_DELTA,
-        SLOTS, START_HEIGHT,
+        create_responder_with_query, generate_dummy_appointment,
+        generate_dummy_appointment_with_user, generate_uuid, get_random_breach, get_random_tracker,
+        get_random_tx, store_appointment_and_its_user, Blockchain, MockedServerQuery, DURATION,
+        EXPIRY_DELTA, SLOTS, START_HEIGHT,
     };
 
-    use teos_common::constants::IRREVOCABLY_RESOLVED;
     use teos_common::test_utils::get_random_user_id;
 
     impl TransactionTracker {
@@ -548,24 +547,6 @@ mod tests {
         }
     }
 
-    async fn create_responder(
-        chain: &mut Blockchain,
-        gatekeeper: Arc<Gatekeeper>,
-        dbm: Arc<Mutex<DBM>>,
-        query: MockedServerQuery,
-    ) -> Responder {
-        let height = if chain.tip().height < IRREVOCABLY_RESOLVED {
-            chain.tip().height
-        } else {
-            IRREVOCABLY_RESOLVED
-        };
-
-        let carrier = create_carrier(query, chain.tip().height);
-        let last_n_blocks = get_last_n_blocks(chain, height as usize).await;
-
-        Responder::new(&last_n_blocks, chain.tip().height, carrier, gatekeeper, dbm)
-    }
-
     async fn init_responder_with_chain_and_dbm(
         mocked_query: MockedServerQuery,
         chain: &mut Blockchain,
@@ -578,7 +559,7 @@ mod tests {
             EXPIRY_DELTA,
             dbm.clone(),
         );
-        create_responder(chain, Arc::new(gk), dbm, mocked_query).await
+        create_responder_with_query(chain, Arc::new(gk), dbm, mocked_query).await
     }
 
     async fn init_responder(mocked_query: MockedServerQuery) -> Responder {

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -8,6 +8,7 @@
 */
 
 use rand::Rng;
+use std::fmt::Debug;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 
@@ -373,7 +374,7 @@ pub(crate) enum MockedServerQuery {
     Error(i64),
 }
 
-pub(crate) fn create_carrier(query: MockedServerQuery, height: u32) -> (Carrier, BitcoindStopper) {
+pub(crate) fn create_carrier(query: MockedServerQuery, height: u32) -> Carrier {
     let bitcoind_mock = match query {
         MockedServerQuery::Regular => BitcoindMock::new(MockOptions::default()),
         MockedServerQuery::InMempoool => BitcoindMock::new(MockOptions::in_mempool()),
@@ -383,9 +384,11 @@ pub(crate) fn create_carrier(query: MockedServerQuery, height: u32) -> (Carrier,
     let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
     start_server(bitcoind_mock.server);
 
-    (
-        Carrier::new(bitcoin_cli, bitcoind_reachable, height),
-        bitcoind_mock.stopper,
+    Carrier::new(
+        bitcoin_cli,
+        bitcoind_reachable,
+        height,
+        Some(bitcoind_mock.stopper),
     )
 }
 
@@ -393,17 +396,12 @@ pub(crate) async fn create_responder(
     chain: &mut Blockchain,
     gatekeeper: Arc<Gatekeeper>,
     dbm: Arc<Mutex<DBM>>,
-    server_url: &str,
 ) -> Responder {
     let height = chain.tip().height;
     // For the local TxIndex logic to be sound, our index needs to have, at least, IRREVOCABLY_RESOLVED blocks
     debug_assert!(height >= IRREVOCABLY_RESOLVED);
-
+    let carrier = create_carrier(MockedServerQuery::Regular, height);
     let last_n_blocks = get_last_n_blocks(chain, IRREVOCABLY_RESOLVED as usize).await;
-
-    let bitcoin_cli = Arc::new(BitcoindClient::new(server_url, Auth::None).unwrap());
-    let bitcoind_reachable = Arc::new((Mutex::new(true), Condvar::new()));
-    let carrier = Carrier::new(bitcoin_cli, bitcoind_reachable, height);
 
     Responder::new(&last_n_blocks, height, carrier, gatekeeper, dbm)
 }
@@ -412,25 +410,21 @@ pub(crate) async fn create_watcher(
     chain: &mut Blockchain,
     responder: Arc<Responder>,
     gatekeeper: Arc<Gatekeeper>,
-    bitcoind_mock: BitcoindMock,
     dbm: Arc<Mutex<DBM>>,
-) -> (Watcher, BitcoindStopper) {
+) -> Watcher {
     let last_n_blocks = get_last_n_blocks(chain, 6).await;
 
-    start_server(bitcoind_mock.server);
     let (tower_sk, tower_pk) = get_random_keypair();
     let tower_id = UserId(tower_pk);
-    (
-        Watcher::new(
-            gatekeeper,
-            responder,
-            &last_n_blocks,
-            chain.get_block_count(),
-            tower_sk,
-            tower_id,
-            dbm,
-        ),
-        bitcoind_mock.stopper,
+
+    Watcher::new(
+        gatekeeper,
+        responder,
+        &last_n_blocks,
+        chain.get_block_count(),
+        tower_sk,
+        tower_id,
+        dbm,
     )
 }
 #[derive(Clone)]
@@ -465,10 +459,7 @@ impl Default for ApiConfig {
     }
 }
 
-pub(crate) async fn create_api_with_config(
-    api_config: ApiConfig,
-) -> (Arc<InternalAPI>, BitcoindStopper) {
-    let bitcoind_mock = BitcoindMock::new(MockOptions::default());
+pub(crate) async fn create_api_with_config(api_config: ApiConfig) -> Arc<InternalAPI> {
     let mut chain = Blockchain::default().with_height(START_HEIGHT);
 
     let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
@@ -479,31 +470,21 @@ pub(crate) async fn create_api_with_config(
         EXPIRY_DELTA,
         dbm.clone(),
     ));
-    let responder =
-        create_responder(&mut chain, gk.clone(), dbm.clone(), bitcoind_mock.url()).await;
-    let (watcher, stopper) = create_watcher(
-        &mut chain,
-        Arc::new(responder),
-        gk.clone(),
-        bitcoind_mock,
-        dbm.clone(),
-    )
-    .await;
+    let responder = create_responder(&mut chain, gk.clone(), dbm.clone()).await;
+    let watcher = create_watcher(&mut chain, Arc::new(responder), gk.clone(), dbm.clone()).await;
 
     let bitcoind_reachable = Arc::new((Mutex::new(api_config.bitcoind_reachable), Condvar::new()));
     let (shutdown_trigger, _) = triggered::trigger();
-    (
-        Arc::new(InternalAPI::new(
-            Arc::new(watcher),
-            vec![msgs::NetworkAddress::from_ipv4("address".to_string(), 21)],
-            bitcoind_reachable,
-            shutdown_trigger,
-        )),
-        stopper,
-    )
+
+    Arc::new(InternalAPI::new(
+        Arc::new(watcher),
+        vec![msgs::NetworkAddress::from_ipv4("address".to_string(), 21)],
+        bitcoind_reachable,
+        shutdown_trigger,
+    ))
 }
 
-pub(crate) async fn create_api() -> (Arc<InternalAPI>, BitcoindStopper) {
+pub(crate) async fn create_api() -> Arc<InternalAPI> {
     create_api_with_config(ApiConfig::default()).await
 }
 
@@ -525,6 +506,15 @@ impl BitcoindStopper {
 impl Drop for BitcoindStopper {
     fn drop(&mut self) {
         self.close_handle().close()
+    }
+}
+
+// Since [`CloseHandle`] doesn't implement debug, we can't derive it on [`BitcoindStopper`].
+// Implement a dummy one instead. This is just to be able to include [`BitcoindStopper`]
+// as a field in debug deriving structs.
+impl Debug for BitcoindStopper {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
     }
 }
 

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -388,7 +388,7 @@ pub(crate) fn create_carrier(query: MockedServerQuery, height: u32) -> Carrier {
         bitcoin_cli,
         bitcoind_reachable,
         height,
-        Some(bitcoind_mock.stopper),
+        bitcoind_mock.stopper,
     )
 }
 
@@ -531,7 +531,7 @@ impl Debug for BitcoindStopper {
 pub(crate) struct BitcoindMock {
     pub url: String,
     pub server: Server,
-    stopper: BitcoindStopper,
+    pub stopper: BitcoindStopper,
 }
 
 #[derive(Default)]


### PR DESCRIPTION
We had to assign the stopper to a variable in the tests so to have it dropped at the end of the test and clean up the spawned mock server.

This refactor makes it so that the stopper is stored in `Carrier` (but only on test mode) and it's dropped whenever the carrier is dropped. I chose to include it in the carrier since the carrier is the struct that talks with bitcoind, so if the carrier is to die so should bitcoind as well.