### PR TITLE
Makes `time` is up to date when compiling CLN for CI jobs

### DIFF
--- a/.github/workflows/cln-plugin.yaml
+++ b/.github/workflows/cln-plugin.yaml
@@ -38,6 +38,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y gettext
           git clone https://github.com/ElementsProject/lightning.git && cd lightning && git checkout v${{ env.cln_version }}
           pip install --user poetry && poetry install
+          cargo update -p time
           ./configure && poetry run make
 
   cln-plugin:


### PR DESCRIPTION
Compiling time with rustc over 1.80.0 (inclusive) results in a crash for old versions of the time crate, which CLN uses. Make sure we are up to date with the current revision