### PR TITLE
Allow watchtower client to call https endoints

### DIFF
--- a/watchtower-plugin/src/main.rs
+++ b/watchtower-plugin/src/main.rs
@@ -107,7 +107,7 @@ async fn register(
     );
 
     let tower_net_addr = {
-        if !host.starts_with("http://") {
+        if !host.starts_with("http://") && !host.starts_with("https://") {
             host = format!("http://{host}")
         }
         NetAddr::new(format!("{host}:{port}"))


### PR DESCRIPTION
If I try to register with a tower at `https://example.com` the client tries to connect to `http://https://example.com`.

I tested the fix with a tower deployed behind an Nginx reverse proxy with TLS and it works as expected.