### PR TITLE
Add ldk-watchtower-client crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,23 +121,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite 0.2.13",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.98",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1418,6 +1419,28 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "ldk-watchtower-client"
+version = "0.1.0"
+dependencies = [
+ "backoff",
+ "bitcoin",
+ "hex",
+ "home",
+ "log",
+ "prost",
+ "reqwest",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "simple_logger",
+ "structopt",
+ "tempdir",
+ "teos-common",
+ "toml",
+ "triggered",
+]
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 
 members = [
+    "ldk-watchtower-client",
     "teos",
     "teos-common",
     "watchtower-plugin"

--- a/ldk-watchtower-client/Cargo.toml
+++ b/ldk-watchtower-client/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "ldk-watchtower-client"
+version = "0.1.0"
+authors = ["Vincenzo Palazzo <vincenzopalazzodev@gmail.com>"]
+license = "MIT"
+edition = "2021"
+description = "Watchtower client for ldk-server nodes. Polls an ldk-server WatchtowerStateExport endpoint and ships teos (Eye of Satoshi) appointments to a tower over Tor."
+
+[[bin]]
+name = "ldk-watchtower-client"
+path = "src/main.rs"
+
+[dependencies]
+# General
+backoff = "0.4.0"
+hex = { version = "0.4.3", features = [ "serde" ] }
+home = "0.5.3"
+log = "0.4"
+prost = "0.12"
+reqwest = { version = "0.11", features = [ "blocking", "json", "socks" ] }
+rusqlite = { version = "0.26.0", features = [ "bundled", "limits" ] }
+serde = "1.0.130"
+serde_json = { version = "1.0", features = [ "preserve_order" ] }
+simple_logger = "2.1.0"
+structopt = "0.3"
+toml = "0.5"
+triggered = "0.1.2"
+
+# Bitcoin and Lightning
+bitcoin = "0.28.0"
+
+# Local
+teos-common = { path = "../teos-common" }
+
+[dev-dependencies]
+tempdir = "0.3.7"

--- a/ldk-watchtower-client/src/appointments.rs
+++ b/ldk-watchtower-client/src/appointments.rs
@@ -1,0 +1,175 @@
+//! Logic to build teos appointments from ldk-server justice transactions.
+//!
+//! teos appointments encrypt the *penalty* (justice) transaction under a key derived
+//! from the dispute (commitment) txid, and are identified by a locator consisting of
+//! the first 16 bytes of that txid.
+//!
+//! In v1, ldk-server exports justice transactions with `signed = false` and empty
+//! `justice_tx` bytes (only `commitment_txid` and `commitment_number` are real, as
+//! locator sources). [build_appointment] therefore only builds appointments from
+//! signed, non-empty entries; the caller is expected to track *all* commitment
+//! txids in its local database so the later transition to signed entries is
+//! detected as new state.
+
+use bitcoin::consensus;
+use bitcoin::hashes::hex::FromHex;
+use bitcoin::{Transaction, Txid};
+
+use teos_common::appointment::{Appointment, Locator};
+use teos_common::cryptography;
+
+use crate::proto::JusticeTransaction;
+
+/// Whether a justice transaction carries everything needed to build an appointment.
+pub fn is_appointment_ready(justice: &JusticeTransaction) -> bool {
+    justice.signed && !justice.justice_tx.is_empty()
+}
+
+/// Builds a teos [Appointment] from a [JusticeTransaction] exported by ldk-server.
+///
+/// Returns `None` (logging at debug level) if the entry is not signed yet or carries
+/// no transaction bytes, and (at warn level) if the entry is malformed. This is the
+/// single place that needs to change if ldk-server's export format evolves.
+pub fn build_appointment(justice: &JusticeTransaction, to_self_delay: u32) -> Option<Appointment> {
+    if !is_appointment_ready(justice) {
+        log::debug!(
+            "Skipping justice transaction for commitment {}: not signed or empty justice tx",
+            justice.commitment_txid
+        );
+        return None;
+    }
+
+    let dispute_txid = match Txid::from_hex(&justice.commitment_txid) {
+        Ok(txid) => txid,
+        Err(e) => {
+            log::warn!(
+                "Cannot build appointment: invalid commitment txid {} ({e})",
+                justice.commitment_txid
+            );
+            return None;
+        }
+    };
+
+    let justice_tx: Transaction = match consensus::deserialize(&justice.justice_tx) {
+        Ok(tx) => tx,
+        Err(e) => {
+            log::warn!(
+                "Cannot build appointment: cannot deserialize justice tx for commitment {} ({e})",
+                justice.commitment_txid
+            );
+            return None;
+        }
+    };
+
+    // The encryption key is sha256(dispute_txid) with nonce [0; 12],
+    // as per `teos_common::cryptography::encrypt`.
+    let encrypted_blob = match cryptography::encrypt(&justice_tx, &dispute_txid) {
+        Ok(blob) => blob,
+        Err(e) => {
+            log::warn!(
+                "Cannot build appointment: encryption failed for commitment {} ({e})",
+                justice.commitment_txid
+            );
+            return None;
+        }
+    };
+
+    Some(Appointment::new(
+        Locator::new(dispute_txid),
+        encrypted_blob,
+        to_self_delay,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub(crate) const HEX_TX: &str = "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff54038e830a1b4d696e656420627920416e74506f6f6c373432c2005b005e7a0ae3fabe6d6d7841cd582ead8ea5dd8e3de1173cae6fcd2a53c7362ebb7fb6f815604fe07cbe0200000000000000ac0e060005f90000ffffffff04d9476026000000001976a91411dbe48cc6b617f9c6adaf4d9ed5f625b1c7cb5988ac0000000000000000266a24aa21a9ed7248c6efddd8d99bfddd7f499f0b915bffa8253003cc934df1ff14a81301e2340000000000000000266a24b9e11b6d7054937e13f39529d6ad7e685e9dd4efa426f247d5f5a5bed58cdddb2d0fa60100000000000000002b6a2952534b424c4f434b3a054a68aa5368740e8b3e3c67bce45619c2cfd07d4d4f0936a5612d2d0034fa0a0120000000000000000000000000000000000000000000000000000000000000000000000000";
+    pub(crate) const HEX_TXID: &str =
+        "d6ac4a5e61657c4c604dcde855a1db74ec6b3e54f32695d72c5e11c7761ea1b4";
+
+    pub(crate) fn signed_justice() -> JusticeTransaction {
+        JusticeTransaction {
+            commitment_txid: HEX_TXID.to_owned(),
+            commitment_number: 42,
+            to_local_value_sats: 100_000,
+            justice_tx: Vec::from_hex(HEX_TX).unwrap(),
+            signed: true,
+        }
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        // The blob of an appointment must decrypt back to the justice transaction
+        // under the same key (sha256(dispute_txid)) the tower would derive from the
+        // dispute txid found on-chain.
+        let tx: Transaction = consensus::deserialize(&Vec::from_hex(HEX_TX).unwrap()).unwrap();
+        let txid = Txid::from_hex(HEX_TXID).unwrap();
+
+        let encrypted_blob = cryptography::encrypt(&tx, &txid).unwrap();
+        assert_eq!(cryptography::decrypt(&encrypted_blob, &txid).unwrap(), tx);
+    }
+
+    #[test]
+    fn test_locator_from_txid() {
+        // The locator is the first 16 bytes of the txid (internal byte order).
+        // Since `Txid`'s hex display is byte-reversed w.r.t. the internal order,
+        // the locator hex is the byte-reversed tail (last 16 bytes) of the txid hex.
+        let txid = Txid::from_hex(HEX_TXID).unwrap();
+        let locator = Locator::new(txid);
+        assert_eq!(locator.to_vec(), txid[..16].to_vec());
+        assert_eq!(locator.to_string(), "b4a11e76c7115e2cd79526f3543e6bec");
+    }
+
+    #[test]
+    fn test_build_appointment_from_signed_entry() {
+        let appointment = build_appointment(&signed_justice(), 144).unwrap();
+
+        let txid = Txid::from_hex(HEX_TXID).unwrap();
+        let tx: Transaction = consensus::deserialize(&Vec::from_hex(HEX_TX).unwrap()).unwrap();
+        assert_eq!(appointment.locator, Locator::new(txid));
+        assert_eq!(appointment.to_self_delay, 144);
+        assert_eq!(
+            cryptography::decrypt(&appointment.encrypted_blob, &txid).unwrap(),
+            tx
+        );
+    }
+
+    #[test]
+    fn test_unsigned_and_empty_entries_are_skipped() {
+        // Unsigned entry with empty justice tx: the v1 ldk-server export format.
+        let unsigned = JusticeTransaction {
+            commitment_txid: HEX_TXID.to_owned(),
+            commitment_number: 42,
+            to_local_value_sats: 100_000,
+            justice_tx: Vec::new(),
+            signed: false,
+        };
+        assert!(build_appointment(&unsigned, 144).is_none());
+
+        // Signed but empty: still not buildable.
+        let signed_empty = JusticeTransaction {
+            justice_tx: Vec::new(),
+            signed: true,
+            ..unsigned.clone()
+        };
+        assert!(build_appointment(&signed_empty, 144).is_none());
+
+        // Unsigned but with tx bytes: not buildable either (the tower would receive
+        // a transaction that cannot be broadcast).
+        let unsigned_nonempty = JusticeTransaction {
+            signed: false,
+            ..signed_justice()
+        };
+        assert!(build_appointment(&unsigned_nonempty, 144).is_none());
+
+        // Signed and non-empty, but malformed tx bytes.
+        let malformed = JusticeTransaction {
+            justice_tx: vec![0xde, 0xad, 0xbe, 0xef],
+            signed: true,
+            ..unsigned
+        };
+        assert!(build_appointment(&malformed, 144).is_none());
+    }
+}

--- a/ldk-watchtower-client/src/config.rs
+++ b/ldk-watchtower-client/src/config.rs
@@ -1,0 +1,153 @@
+//! Command line and configuration file handling, mirroring `teos/src/config.rs`.
+
+use serde::Deserialize;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// Resolves `~`-prefixed data directories to absolute paths.
+pub fn data_dir_absolute_path(data_dir: String) -> PathBuf {
+    if let Some(a) = data_dir.strip_prefix('~') {
+        if let Some(b) = data_dir.strip_prefix("~/") {
+            home::home_dir().unwrap().join(b)
+        } else {
+            home::home_dir().unwrap().join(a)
+        }
+    } else {
+        PathBuf::from(&data_dir)
+    }
+}
+
+/// Loads a TOML config file, falling back to defaults on failure.
+pub fn from_file<T: Default + serde::de::DeserializeOwned>(path: &PathBuf) -> T {
+    match std::fs::read(path) {
+        Ok(file_content) => toml::from_slice::<T>(&file_content).unwrap_or_else(|e| {
+            eprintln!("Couldn't parse config file: {e}");
+            T::default()
+        }),
+        Err(_) => T::default(),
+    }
+}
+
+/// Error raised if something is wrong with the configuration.
+#[derive(PartialEq, Eq, Debug)]
+pub struct ConfigError(String);
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Configuration error: {}", self.0)
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+/// Holds all the command line options.
+#[derive(StructOpt, Debug, Clone)]
+#[structopt(rename_all = "lowercase")]
+#[structopt(
+    version = env!("CARGO_PKG_VERSION"),
+    about = "Watchtower client for ldk-server nodes (ships teos appointments to an Eye of Satoshi tower)"
+)]
+pub struct Opt {
+    /// Base URL of the ldk-server node API (e.g. http://localhost:3002)
+    #[structopt(long)]
+    pub ldk_server_url: Option<String>,
+
+    /// API key used to authenticate against the ldk-server API (HMAC-SHA256)
+    #[structopt(long)]
+    pub api_key: Option<String>,
+
+    /// Hex-encoded public key (33 bytes) identifying the tower
+    #[structopt(long)]
+    pub tower_id: Option<String>,
+
+    /// Tower network address, host:port or onion (e.g. teos.talaia.watch:9814)
+    #[structopt(long)]
+    pub tower_net_addr: Option<String>,
+
+    /// Tor SOCKS5 proxy address used to reach onion towers [default: 127.0.0.1:9050]
+    #[structopt(long, default_value = "127.0.0.1:9050")]
+    pub tor_proxy: String,
+
+    /// Specify data directory [default: ~/.ldk-watchtower]
+    #[structopt(long, default_value = "~/.ldk-watchtower")]
+    pub data_dir: String,
+
+    /// How often the ldk-server watchtower state is polled, in seconds [default: 60]
+    #[structopt(long)]
+    pub poll_interval_secs: Option<u64>,
+
+    /// Watch only this `user_channel_id` (hex). Repeatable. If unset, all channels
+    /// returned by the export endpoint are watched
+    #[structopt(long)]
+    pub watch_channel: Vec<String>,
+
+    /// Path to a TOML configuration file. Command line options take precedence
+    #[structopt(long, parse(from_os_str))]
+    pub config: Option<PathBuf>,
+}
+
+/// Optional TOML configuration file content. All fields default to `None`/empty and
+/// are overridden by their command line counterparts.
+#[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields, default)]
+pub struct ConfigFile {
+    pub ldk_server_url: Option<String>,
+    pub api_key: Option<String>,
+    pub tower_id: Option<String>,
+    pub tower_net_addr: Option<String>,
+    pub tor_proxy: Option<String>,
+    pub data_dir: Option<String>,
+    pub poll_interval_secs: Option<u64>,
+    pub watch_channel: Vec<String>,
+}
+
+/// The fully-resolved configuration the client runs with.
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub ldk_server_url: String,
+    pub api_key: String,
+    pub tower_id: String,
+    pub tower_net_addr: String,
+    pub tor_proxy: String,
+    pub data_dir: PathBuf,
+    pub poll_interval_secs: u64,
+    pub watch_channels: Vec<String>,
+}
+
+impl Config {
+    pub fn from_opt(opt: Opt) -> Result<Config, ConfigError> {
+        let file = opt
+            .config
+            .as_ref()
+            .map(from_file::<ConfigFile>)
+            .unwrap_or_default();
+
+        let required = |name: &str,
+                        cli: Option<String>,
+                        file: Option<String>|
+         -> Result<String, ConfigError> {
+            cli.or(file)
+                .ok_or_else(|| ConfigError(format!("--{name} is required")))
+        };
+
+        Ok(Config {
+            ldk_server_url: required("ldk-server-url", opt.ldk_server_url, file.ldk_server_url)?,
+            api_key: required("api-key", opt.api_key, file.api_key)?,
+            tower_id: required("tower-id", opt.tower_id, file.tower_id)?,
+            tower_net_addr: required("tower-net-addr", opt.tower_net_addr, file.tower_net_addr)?,
+            // `tor_proxy` and `data_dir` have CLI defaults, so they always come
+            // from the command line (which mirrors teos' behavior).
+            tor_proxy: opt.tor_proxy,
+            data_dir: data_dir_absolute_path(opt.data_dir),
+            poll_interval_secs: opt
+                .poll_interval_secs
+                .or(file.poll_interval_secs)
+                .unwrap_or(60),
+            watch_channels: if opt.watch_channel.is_empty() {
+                file.watch_channel
+            } else {
+                opt.watch_channel
+            },
+        })
+    }
+}

--- a/ldk-watchtower-client/src/dbm.rs
+++ b/ldk-watchtower-client/src/dbm.rs
@@ -1,0 +1,407 @@
+//! SQLite-backed persistence for the watchtower client.
+//!
+//! Mirrors the patterns of `watchtower-plugin/src/dbm.rs`. The database is the
+//! pending queue: every exported commitment state is tracked here, so no
+//! appointment is ever lost across restarts.
+//!
+//! State machine for tracked commitment states (`justice_states.status`):
+//! - `seen`:    commitment txid tracked, but no signed justice tx available yet.
+//! - `pending`: a signed justice tx is available; the appointment still needs to
+//!              be (re-)sent to the tower (e.g. after a connection failure or a restart).
+//! - `sent`:    the tower accepted the appointment (receipt stored).
+//! - `invalid`: the tower permanently rejected the appointment, or it misbehaved.
+
+use std::path::Path;
+
+use rusqlite::{params, Connection, Error};
+
+use bitcoin::secp256k1::SecretKey;
+
+use teos_common::receipts::{AppointmentReceipt, RegistrationReceipt};
+use teos_common::{TowerId, UserId};
+
+use crate::tower::MisbehaviorProof;
+
+const TABLES: [&str; 5] = [
+    "CREATE TABLE IF NOT EXISTS keys (
+        id INTEGER PRIMARY KEY,
+        key BLOB NOT NULL
+    )",
+    "CREATE TABLE IF NOT EXISTS registration_receipts (
+        tower_id TEXT PRIMARY KEY,
+        available_slots INT NOT NULL,
+        subscription_start INT NOT NULL,
+        subscription_expiry INT NOT NULL,
+        signature TEXT NOT NULL
+    )",
+    "CREATE TABLE IF NOT EXISTS justice_states (
+        commitment_txid TEXT PRIMARY KEY,
+        user_channel_id TEXT NOT NULL,
+        commitment_number INT NOT NULL,
+        to_local_value_sats INT NOT NULL,
+        to_self_delay INT NOT NULL,
+        justice_tx BLOB NOT NULL,
+        status TEXT NOT NULL
+    )",
+    "CREATE TABLE IF NOT EXISTS appointment_receipts (
+        locator TEXT PRIMARY KEY,
+        user_signature TEXT NOT NULL,
+        start_block INT NOT NULL,
+        signature TEXT NOT NULL
+    )",
+    "CREATE TABLE IF NOT EXISTS misbehaving_proofs (
+        tower_id TEXT PRIMARY KEY,
+        locator TEXT NOT NULL,
+        appointment_receipt TEXT NOT NULL,
+        recovered_id TEXT NOT NULL
+    )",
+];
+
+/// The status of a tracked commitment state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StateStatus {
+    Seen,
+    Pending,
+    Sent,
+    Invalid,
+}
+
+impl std::fmt::Display for StateStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            StateStatus::Seen => "seen",
+            StateStatus::Pending => "pending",
+            StateStatus::Sent => "sent",
+            StateStatus::Invalid => "invalid",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl std::str::FromStr for StateStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "seen" => Ok(StateStatus::Seen),
+            "pending" => Ok(StateStatus::Pending),
+            "sent" => Ok(StateStatus::Sent),
+            "invalid" => Ok(StateStatus::Invalid),
+            _ => Err(format!("Unknown status: {s}")),
+        }
+    }
+}
+
+/// A tracked justice transaction, as persisted in the database.
+#[derive(Clone, Debug)]
+pub struct TrackedJustice {
+    pub commitment_txid: String,
+    pub user_channel_id: String,
+    pub commitment_number: u64,
+    pub to_local_value_sats: u64,
+    pub to_self_delay: u32,
+    pub justice_tx: Vec<u8>,
+    pub status: StateStatus,
+}
+
+pub struct DBM {
+    connection: Connection,
+}
+
+impl DBM {
+    pub fn new(db_path: &Path) -> Result<Self, Error> {
+        let connection = Connection::open(db_path)?;
+        for table in TABLES.iter() {
+            connection.execute(table, [])?;
+        }
+        Ok(DBM { connection })
+    }
+
+    #[cfg(test)]
+    pub fn in_memory() -> Result<Self, Error> {
+        let connection = Connection::open_in_memory()?;
+        for table in TABLES.iter() {
+            connection.execute(table, [])?;
+        }
+        Ok(DBM { connection })
+    }
+
+    /// Stores the client secret key used to sign appointments (single row).
+    pub fn store_client_key(&self, sk: &SecretKey) -> Result<(), Error> {
+        self.connection.execute(
+            "INSERT OR REPLACE INTO keys (id, key) VALUES (0, ?1)",
+            params![sk.secret_bytes().to_vec()],
+        )?;
+        Ok(())
+    }
+
+    /// Loads the client secret key, if any was stored.
+    pub fn load_client_key(&self) -> Option<SecretKey> {
+        self.connection
+            .query_row("SELECT key FROM keys WHERE id = 0", [], |row| {
+                row.get::<_, Vec<u8>>(0)
+            })
+            .ok()
+            .and_then(|bytes| SecretKey::from_slice(&bytes).ok())
+    }
+
+    /// Stores (or replaces) the registration receipt for a tower.
+    pub fn store_registration_receipt(
+        &self,
+        tower_id: TowerId,
+        receipt: &RegistrationReceipt,
+    ) -> Result<(), Error> {
+        self.connection.execute(
+            "INSERT OR REPLACE INTO registration_receipts
+                (tower_id, available_slots, subscription_start, subscription_expiry, signature)
+            VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                tower_id.to_string(),
+                receipt.available_slots(),
+                receipt.subscription_start(),
+                receipt.subscription_expiry(),
+                receipt.signature().unwrap_or_default(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Loads the registration receipt for a tower, if any.
+    pub fn load_registration_receipt(
+        &self,
+        tower_id: TowerId,
+        user_id: UserId,
+    ) -> Option<RegistrationReceipt> {
+        self.connection
+            .query_row(
+                "SELECT available_slots, subscription_start, subscription_expiry, signature
+                 FROM registration_receipts WHERE tower_id = ?1",
+                params![tower_id.to_string()],
+                |row| {
+                    Ok(RegistrationReceipt::with_signature(
+                        user_id,
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                    ))
+                },
+            )
+            .ok()
+    }
+
+    /// Tracks a justice transaction in the database.
+    ///
+    /// Returns the status the state is left in. A state that was already `sent` or
+    /// `invalid` is never downgraded; a state transitioning from `seen` (or new)
+    /// with signed justice tx data becomes `pending`.
+    pub fn track_justice(&self, justice: &TrackedJustice) -> Result<StateStatus, Error> {
+        match self.load_justice(&justice.commitment_txid)? {
+            Some(existing) => {
+                if matches!(existing.status, StateStatus::Sent | StateStatus::Invalid) {
+                    return Ok(existing.status);
+                }
+                // Upgrade a `seen` state to `pending` once signed data is available.
+                let status = if justice.justice_tx.is_empty() {
+                    existing.status
+                } else {
+                    StateStatus::Pending
+                };
+                self.connection.execute(
+                    "UPDATE justice_states SET user_channel_id = ?2, commitment_number = ?3,
+                        to_local_value_sats = ?4, to_self_delay = ?5, justice_tx = ?6, status = ?7
+                     WHERE commitment_txid = ?1",
+                    params![
+                        justice.commitment_txid,
+                        justice.user_channel_id,
+                        justice.commitment_number,
+                        justice.to_local_value_sats,
+                        justice.to_self_delay,
+                        if justice.justice_tx.is_empty() {
+                            existing.justice_tx
+                        } else {
+                            justice.justice_tx.clone()
+                        },
+                        status.to_string(),
+                    ],
+                )?;
+                Ok(status)
+            }
+            None => {
+                let status = if justice.justice_tx.is_empty() {
+                    StateStatus::Seen
+                } else {
+                    StateStatus::Pending
+                };
+                self.connection.execute(
+                    "INSERT INTO justice_states
+                        (commitment_txid, user_channel_id, commitment_number, to_local_value_sats,
+                         to_self_delay, justice_tx, status)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    params![
+                        justice.commitment_txid,
+                        justice.user_channel_id,
+                        justice.commitment_number,
+                        justice.to_local_value_sats,
+                        justice.to_self_delay,
+                        justice.justice_tx,
+                        status.to_string(),
+                    ],
+                )?;
+                Ok(status)
+            }
+        }
+    }
+
+    /// Loads a tracked justice transaction by commitment txid.
+    pub fn load_justice(&self, commitment_txid: &str) -> Result<Option<TrackedJustice>, Error> {
+        let mut stmt = self.connection.prepare(
+            "SELECT commitment_txid, user_channel_id, commitment_number, to_local_value_sats,
+                    to_self_delay, justice_tx, status
+             FROM justice_states WHERE commitment_txid = ?1",
+        )?;
+        let mut rows = stmt.query(params![commitment_txid])?;
+        match rows.next()? {
+            Some(row) => {
+                let status: String = row.get(6)?;
+                Ok(Some(TrackedJustice {
+                    commitment_txid: row.get(0)?,
+                    user_channel_id: row.get(1)?,
+                    commitment_number: row.get(2)?,
+                    to_local_value_sats: row.get(3)?,
+                    to_self_delay: row.get(4)?,
+                    justice_tx: row.get(5)?,
+                    status: status.parse().unwrap_or(StateStatus::Seen),
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Loads all states awaiting (re-)delivery to the tower.
+    pub fn load_pending_justices(&self) -> Result<Vec<TrackedJustice>, Error> {
+        let mut stmt = self.connection.prepare(
+            "SELECT commitment_txid, user_channel_id, commitment_number, to_local_value_sats,
+                    to_self_delay, justice_tx, status
+             FROM justice_states WHERE status = 'pending'",
+        )?;
+        let mut rows = stmt.query([])?;
+        let mut result = Vec::new();
+        while let Some(row) = rows.next()? {
+            let status: String = row.get(6)?;
+            result.push(TrackedJustice {
+                commitment_txid: row.get(0)?,
+                user_channel_id: row.get(1)?,
+                commitment_number: row.get(2)?,
+                to_local_value_sats: row.get(3)?,
+                to_self_delay: row.get(4)?,
+                justice_tx: row.get(5)?,
+                status: status.parse().unwrap_or(StateStatus::Pending),
+            });
+        }
+        Ok(result)
+    }
+
+    /// Sets the status of a tracked state.
+    pub fn set_justice_status(
+        &self,
+        commitment_txid: &str,
+        status: StateStatus,
+    ) -> Result<(), Error> {
+        self.connection.execute(
+            "UPDATE justice_states SET status = ?2 WHERE commitment_txid = ?1",
+            params![commitment_txid, status.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// Stores the receipt issued by the tower for an accepted appointment.
+    pub fn store_appointment_receipt(
+        &self,
+        locator: &str,
+        receipt: &AppointmentReceipt,
+    ) -> Result<(), Error> {
+        self.connection.execute(
+            "INSERT OR REPLACE INTO appointment_receipts (locator, user_signature, start_block, signature)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                locator,
+                receipt.user_signature(),
+                receipt.start_block(),
+                receipt.signature().unwrap_or_default(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Stores proof that a tower signed a receipt with a key not matching its tower id.
+    pub fn store_misbehaving_proof(
+        &self,
+        tower_id: TowerId,
+        proof: &MisbehaviorProof,
+    ) -> Result<(), Error> {
+        self.connection.execute(
+            "INSERT OR REPLACE INTO misbehaving_proofs (tower_id, locator, appointment_receipt, recovered_id)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                tower_id.to_string(),
+                proof.locator.to_string(),
+                serde_json::to_string(&proof.appointment_receipt).unwrap(),
+                proof.recovered_id.to_string(),
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tracked(txid: &str, justice_tx: Vec<u8>) -> TrackedJustice {
+        TrackedJustice {
+            commitment_txid: txid.to_owned(),
+            user_channel_id: "abcd".to_owned(),
+            commitment_number: 42,
+            to_local_value_sats: 100_000,
+            to_self_delay: 144,
+            justice_tx,
+            status: StateStatus::Seen,
+        }
+    }
+
+    #[test]
+    fn test_track_justice_transitions() {
+        let dbm = DBM::in_memory().unwrap();
+        let txid = "d6ac4a5e61657c4c604dcde855a1db74ec6b3e54f32695d72c5e11c7761ea1b4";
+
+        // Unsigned (empty justice tx) entries are tracked as `seen`.
+        let status = dbm.track_justice(&tracked(txid, Vec::new())).unwrap();
+        assert_eq!(status, StateStatus::Seen);
+
+        // The transition to a signed entry (justice tx bytes present) is detected
+        // as new state: the entry becomes `pending`.
+        let status = dbm.track_justice(&tracked(txid, vec![1, 2, 3])).unwrap();
+        assert_eq!(status, StateStatus::Pending);
+        assert_eq!(dbm.load_pending_justices().unwrap().len(), 1);
+        assert_eq!(
+            dbm.load_justice(txid).unwrap().unwrap().justice_tx,
+            vec![1, 2, 3]
+        );
+
+        // Once sent, re-tracking the same state does not downgrade it.
+        dbm.set_justice_status(txid, StateStatus::Sent).unwrap();
+        let status = dbm.track_justice(&tracked(txid, vec![1, 2, 3])).unwrap();
+        assert_eq!(status, StateStatus::Sent);
+        assert!(dbm.load_pending_justices().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_client_key_roundtrip() {
+        let dbm = DBM::in_memory().unwrap();
+        assert!(dbm.load_client_key().is_none());
+        let sk = SecretKey::from_slice(&[1u8; 32]).unwrap();
+        dbm.store_client_key(&sk).unwrap();
+        assert_eq!(dbm.load_client_key().unwrap(), sk);
+    }
+}

--- a/ldk-watchtower-client/src/ldk_client.rs
+++ b/ldk-watchtower-client/src/ldk_client.rs
@@ -1,0 +1,170 @@
+//! HTTP client for the ldk-server `WatchtowerStateExport` endpoint.
+//!
+//! The transport mirrors ldk-server's protobuf-over-HTTP API: requests are sent as
+//! HTTP POSTs to `{base_url}/{ApiName}` with a protobuf-encoded body and
+//! `Content-Type: application/octet-stream`.
+//!
+//! Authentication mirrors `validate_auth` in `ldk-server/src/service.rs`: an
+//! `x-auth: HMAC {timestamp}:{hmac_hex}` header where `hmac_hex` is the hex-encoded
+//! HMAC-SHA256 (keyed with the API key) of `timestamp (8 bytes, big endian) || body`.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use bitcoin::hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
+use prost::Message;
+
+use crate::proto::{
+    WatchtowerStateExportRequest, WatchtowerStateExportResponse, WATCHTOWER_STATE_EXPORT_PATH,
+};
+
+/// Errors that can occur while interacting with the ldk-server API.
+#[derive(Debug)]
+pub enum LdkClientError {
+    /// A network-level error (connection refused, timeout, ...).
+    ConnectionError(String),
+    /// The server returned a non-success status code.
+    ApiError(u16, String),
+    /// The response body could not be protobuf-decoded.
+    DeserializeError(String),
+    /// The system clock is set before the UNIX epoch.
+    SystemTimeError,
+}
+
+impl std::fmt::Display for LdkClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LdkClientError::ConnectionError(e) => write!(f, "cannot connect to ldk-server: {e}"),
+            LdkClientError::ApiError(code, msg) => {
+                write!(f, "ldk-server API error ({code}): {msg}")
+            }
+            LdkClientError::DeserializeError(e) => {
+                write!(f, "cannot decode ldk-server response: {e}")
+            }
+            LdkClientError::SystemTimeError => write!(f, "system time is before the UNIX epoch"),
+        }
+    }
+}
+
+impl std::error::Error for LdkClientError {}
+
+impl LdkClientError {
+    pub fn is_connection(&self) -> bool {
+        matches!(self, LdkClientError::ConnectionError(_))
+    }
+}
+
+/// Computes the authentication HMAC expected by ldk-server: HMAC-SHA256 keyed with
+/// the API key over `timestamp.to_be_bytes() || body`, hex-encoded.
+pub fn compute_auth_hmac(api_key: &str, timestamp: u64, body: &[u8]) -> String {
+    let mut hmac_engine: HmacEngine<sha256::Hash> = HmacEngine::new(api_key.as_bytes());
+    hmac_engine.input(&timestamp.to_be_bytes());
+    hmac_engine.input(body);
+    Hmac::<sha256::Hash>::from_engine(hmac_engine).to_string()
+}
+
+/// Blocking HTTP client for the ldk-server watchtower state export API.
+pub struct LdkServerClient {
+    base_url: String,
+    api_key: String,
+    client: reqwest::blocking::Client,
+}
+
+impl LdkServerClient {
+    pub fn new(base_url: String, api_key: String) -> Self {
+        LdkServerClient {
+            base_url: base_url.trim_end_matches('/').to_owned(),
+            api_key,
+            client: reqwest::blocking::Client::new(),
+        }
+    }
+
+    /// Performs a protobuf-encoded, HMAC-authenticated POST to the given endpoint and
+    /// protobuf-decodes the response.
+    fn post<Req: Message, Res: Message + Default>(
+        &self,
+        path: &str,
+        request: &Req,
+    ) -> Result<Res, LdkClientError> {
+        let body = request.encode_to_vec();
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| LdkClientError::SystemTimeError)?
+            .as_secs();
+        let auth_header = format!(
+            "HMAC {}:{}",
+            timestamp,
+            compute_auth_hmac(&self.api_key, timestamp, &body)
+        );
+
+        let response = self
+            .client
+            .post(format!("{}/{}", self.base_url, path))
+            .header("content-type", "application/octet-stream")
+            .header("x-auth", auth_header)
+            .body(body)
+            .send()
+            .map_err(|e| {
+                log::debug!("Error sending request to ldk-server: {e}");
+                LdkClientError::ConnectionError(format!("{e}"))
+            })?;
+
+        let status = response.status();
+        let response_body = response
+            .bytes()
+            .map_err(|e| LdkClientError::ConnectionError(format!("{e}")))?;
+
+        if !status.is_success() {
+            return Err(LdkClientError::ApiError(
+                status.as_u16(),
+                String::from_utf8_lossy(&response_body).into_owned(),
+            ));
+        }
+
+        Res::decode(response_body.as_ref())
+            .map_err(|e| LdkClientError::DeserializeError(format!("{e}")))
+    }
+
+    /// Exports the watchtower state of a single channel (if `user_channel_id` is set)
+    /// or of all channels (if `None`).
+    pub fn watchtower_state_export(
+        &self,
+        user_channel_id: Option<String>,
+    ) -> Result<WatchtowerStateExportResponse, LdkClientError> {
+        self.post(
+            WATCHTOWER_STATE_EXPORT_PATH,
+            &WatchtowerStateExportRequest { user_channel_id },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_auth_hmac() {
+        // Cross-checked against the algorithm in ldk-server's `compute_auth_hmac`:
+        // HMAC-SHA256(key = api_key, msg = timestamp.to_be_bytes() || body), hex-encoded.
+        let hmac = compute_auth_hmac("secret-api-key", 1_700_000_000, b"watchtower");
+        assert_eq!(hmac.len(), 64);
+        assert!(hmac.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Deterministic for the same inputs, different for different bodies/keys/timestamps.
+        assert_eq!(
+            hmac,
+            compute_auth_hmac("secret-api-key", 1_700_000_000, b"watchtower")
+        );
+        assert_ne!(
+            hmac,
+            compute_auth_hmac("secret-api-key", 1_700_000_001, b"watchtower")
+        );
+        assert_ne!(
+            hmac,
+            compute_auth_hmac("secret-api-key", 1_700_000_000, b"other")
+        );
+        assert_ne!(
+            hmac,
+            compute_auth_hmac("other-key", 1_700_000_000, b"watchtower")
+        );
+    }
+}

--- a/ldk-watchtower-client/src/lib.rs
+++ b/ldk-watchtower-client/src/lib.rs
@@ -1,0 +1,14 @@
+//! Watchtower client for ldk-server nodes.
+//!
+//! Polls an ldk-server node's `WatchtowerStateExport` endpoint and ships teos
+//! (Eye of Satoshi) appointments for new signed justice transactions to a tower,
+//! possibly over Tor. The ldk-server analogue of the CLN `watchtower-plugin`.
+
+pub mod appointments;
+pub mod config;
+pub mod dbm;
+pub mod ldk_client;
+pub mod poller;
+pub mod proto;
+pub mod retrier;
+pub mod tower;

--- a/ldk-watchtower-client/src/main.rs
+++ b/ldk-watchtower-client/src/main.rs
@@ -1,0 +1,54 @@
+use std::time::Duration;
+
+use structopt::StructOpt;
+
+use ldk_watchtower_client::config::{Config, Opt};
+use ldk_watchtower_client::poller::WatchtowerClient;
+
+fn main() {
+    simple_logger::init_with_level(log::Level::Info).unwrap();
+
+    let opt = Opt::from_args();
+    let cfg = match Config::from_opt(opt) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            log::error!("{e}");
+            std::process::exit(1);
+        }
+    };
+
+    let client = match WatchtowerClient::new(cfg.clone()) {
+        Ok(client) => client,
+        Err(e) => {
+            log::error!("Cannot start the watchtower client: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let poll_interval = Duration::from_secs(cfg.poll_interval_secs);
+    let (_trigger, listener) = triggered::trigger();
+    log::info!(
+        "ldk-watchtower-client started. Polling {} every {}s",
+        cfg.ldk_server_url,
+        cfg.poll_interval_secs
+    );
+
+    loop {
+        client.tick();
+        // Sleep until the next tick, waking up periodically to check for
+        // Ctrl-C / SIGTERM (triggered 0.1 has no timed wait on `Listener`).
+        let mut slept = Duration::ZERO;
+        while slept < poll_interval && !listener.is_triggered() {
+            let step = poll_interval
+                .checked_sub(slept)
+                .unwrap_or_default()
+                .min(Duration::from_secs(1));
+            std::thread::sleep(step);
+            slept += step;
+        }
+        if listener.is_triggered() {
+            log::info!("Shutting down");
+            break;
+        }
+    }
+}

--- a/ldk-watchtower-client/src/poller.rs
+++ b/ldk-watchtower-client/src/poller.rs
@@ -1,0 +1,341 @@
+//! The main polling loop: exports the watchtower state from ldk-server and ships
+//! appointments for new signed justice transactions to the tower.
+
+use std::collections::HashSet;
+use std::str::FromStr;
+use std::time::Duration;
+
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+use teos_common::appointment::Appointment;
+use teos_common::cryptography;
+use teos_common::net::NetAddr;
+use teos_common::{TowerId, UserId};
+
+use crate::appointments::build_appointment;
+use crate::config::Config;
+use crate::dbm::{StateStatus, TrackedJustice, DBM};
+use crate::ldk_client::LdkServerClient;
+use crate::proto::{JusticeTransaction, WatchtowerChannelState};
+use crate::retrier::{retry_with_backoff, RetryError};
+use crate::tower::{register, send_appointment, ProxyInfo};
+
+/// Cap the per-appointment retry budget so a single unreachable tower cannot
+/// starve the polling loop for too long.
+const MAX_RETRY_ELAPSED_SECS: u64 = 300;
+
+/// Errors that prevent the client from starting up.
+#[derive(Debug)]
+pub enum ClientError {
+    Db(rusqlite::Error),
+    Io(std::io::Error),
+    InvalidTowerId(String),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::Db(e) => write!(f, "database error: {e}"),
+            ClientError::Io(e) => write!(f, "i/o error: {e}"),
+            ClientError::InvalidTowerId(e) => write!(f, "invalid tower id: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+impl From<rusqlite::Error> for ClientError {
+    fn from(e: rusqlite::Error) -> Self {
+        ClientError::Db(e)
+    }
+}
+
+pub struct WatchtowerClient {
+    cfg: Config,
+    ldk: LdkServerClient,
+    dbm: DBM,
+    user_sk: SecretKey,
+    user_id: UserId,
+    tower_id: TowerId,
+    tower_net_addr: NetAddr,
+    proxy: Option<ProxyInfo>,
+}
+
+impl WatchtowerClient {
+    pub fn new(cfg: Config) -> Result<WatchtowerClient, ClientError> {
+        std::fs::create_dir_all(&cfg.data_dir).map_err(ClientError::Io)?;
+        let dbm = DBM::new(&cfg.data_dir.join("watchtower_db.sql3"))?;
+
+        // Load (or generate and persist) the keypair identifying us to the tower.
+        // The user id is the compressed public key; appointments are signed with
+        // the secret key, as in `watchtower-plugin/src/wt_client.rs`.
+        let (user_sk, user_id) = if let Some(sk) = dbm.load_client_key() {
+            (
+                sk,
+                UserId(PublicKey::from_secret_key(&Secp256k1::new(), &sk)),
+            )
+        } else {
+            let (sk, pk) = cryptography::get_random_keypair();
+            dbm.store_client_key(&sk)?;
+            (sk, UserId(pk))
+        };
+        log::info!("User id = {user_id}");
+
+        let tower_id = TowerId::from_str(&cfg.tower_id).map_err(ClientError::InvalidTowerId)?;
+
+        // The tower API is plain HTTP(S); prepend a scheme if none was given.
+        let net_addr = if cfg.tower_net_addr.starts_with("http") {
+            cfg.tower_net_addr.clone()
+        } else {
+            format!("http://{}", cfg.tower_net_addr)
+        };
+        let tower_net_addr = NetAddr::new(net_addr);
+
+        // Onion towers are only reachable through the Tor proxy.
+        let proxy = if tower_net_addr.is_onion() {
+            log::info!(
+                "Tower is an onion address, routing through Tor proxy at {}",
+                cfg.tor_proxy
+            );
+            Some(ProxyInfo::new(cfg.tor_proxy.clone()))
+        } else {
+            None
+        };
+
+        Ok(WatchtowerClient {
+            ldk: LdkServerClient::new(cfg.ldk_server_url.clone(), cfg.api_key.clone()),
+            cfg,
+            dbm,
+            user_sk,
+            user_id,
+            tower_id,
+            tower_net_addr,
+            proxy,
+        })
+    }
+
+    /// Registers with the tower unless a registration receipt is already persisted.
+    fn ensure_registered(&self) {
+        if self
+            .dbm
+            .load_registration_receipt(self.tower_id, self.user_id)
+            .is_some()
+        {
+            log::debug!("Already registered with {}", self.tower_id);
+            return;
+        }
+
+        match register(
+            self.tower_id,
+            self.user_id,
+            &self.tower_net_addr,
+            &self.proxy,
+        ) {
+            Ok(receipt) => {
+                log::info!(
+                    "Registered with {} (slots: {}, expiry: {})",
+                    self.tower_id,
+                    receipt.available_slots(),
+                    receipt.subscription_expiry()
+                );
+                if let Err(e) = self.dbm.store_registration_receipt(self.tower_id, &receipt) {
+                    log::error!("Cannot persist registration receipt: {e}");
+                }
+            }
+            Err(e) => log::error!("Cannot register with the tower: {e}"),
+        }
+    }
+
+    /// Exports the watchtower state from ldk-server, either for all channels or
+    /// filtered to the configured watch list.
+    fn export_state(&self) -> Vec<WatchtowerChannelState> {
+        let requests: Vec<Option<String>> = if self.cfg.watch_channels.is_empty() {
+            vec![None]
+        } else {
+            self.cfg.watch_channels.iter().cloned().map(Some).collect()
+        };
+
+        let mut states = Vec::new();
+        for user_channel_id in requests {
+            match self.ldk.watchtower_state_export(user_channel_id) {
+                Ok(response) => states.extend(response.channel_states),
+                Err(e) => log::warn!("Cannot export watchtower state from ldk-server: {e}"),
+            }
+        }
+
+        // Defensive client-side filtering in case the server ignores the filter.
+        if !self.cfg.watch_channels.is_empty() {
+            let watched: HashSet<&String> = self.cfg.watch_channels.iter().collect();
+            states.retain(|s| watched.contains(&s.user_channel_id));
+        }
+        states
+    }
+
+    /// Tracks all exported justice transactions and ships appointments for the
+    /// ones that are signed and not yet delivered.
+    fn process_exported_states(&self) {
+        let states = self.export_state();
+        log::debug!(
+            "Exported state for {} channel(s) from ldk-server",
+            states.len()
+        );
+
+        for state in states {
+            for justice in &state.justice_transactions {
+                let tracked = TrackedJustice {
+                    commitment_txid: justice.commitment_txid.clone(),
+                    user_channel_id: state.user_channel_id.clone(),
+                    commitment_number: justice.commitment_number,
+                    to_local_value_sats: justice.to_local_value_sats,
+                    to_self_delay: state.to_self_delay,
+                    // Only signed entries carry usable transaction bytes.
+                    justice_tx: if justice.signed {
+                        justice.justice_tx.clone()
+                    } else {
+                        Vec::new()
+                    },
+                    status: StateStatus::Seen,
+                };
+                match self.dbm.track_justice(&tracked) {
+                    Ok(StateStatus::Pending) => self.deliver(&justice.commitment_txid),
+                    Ok(_) => {}
+                    Err(e) => log::error!(
+                        "Cannot persist justice state {}: {e}",
+                        justice.commitment_txid
+                    ),
+                }
+            }
+        }
+    }
+
+    /// Retries delivery of every appointment still pending in the database
+    /// (e.g. left over from a previous run).
+    fn retry_pending(&self) {
+        match self.dbm.load_pending_justices() {
+            Ok(pending) => {
+                for tracked in pending {
+                    self.deliver(&tracked.commitment_txid);
+                }
+            }
+            Err(e) => log::error!("Cannot load pending appointments from the database: {e}"),
+        }
+    }
+
+    /// Builds, signs and sends the appointment for a tracked (pending) justice
+    /// transaction to the tower, persisting the outcome.
+    fn deliver(&self, commitment_txid: &str) {
+        let tracked = match self.dbm.load_justice(commitment_txid) {
+            Ok(Some(t)) if t.status == StateStatus::Pending => t,
+            Ok(_) => return,
+            Err(e) => {
+                log::error!("Cannot load justice state {commitment_txid}: {e}");
+                return;
+            }
+        };
+
+        let appointment = match self.build_appointment(&tracked) {
+            Some(a) => a,
+            None => {
+                log::warn!("Cannot build appointment for {commitment_txid}, flagging as invalid");
+                let _ = self
+                    .dbm
+                    .set_justice_status(commitment_txid, StateStatus::Invalid);
+                return;
+            }
+        };
+
+        self.send(&tracked, appointment);
+    }
+
+    /// Builds an appointment from a tracked state. Thin wrapper around
+    /// [build_appointment] so the on-disk representation maps to the proto one.
+    fn build_appointment(&self, tracked: &TrackedJustice) -> Option<Appointment> {
+        build_appointment(
+            &JusticeTransaction {
+                commitment_txid: tracked.commitment_txid.clone(),
+                commitment_number: tracked.commitment_number,
+                to_local_value_sats: tracked.to_local_value_sats,
+                justice_tx: tracked.justice_tx.clone(),
+                signed: true,
+            },
+            tracked.to_self_delay,
+        )
+    }
+
+    fn send(&self, tracked: &TrackedJustice, appointment: Appointment) {
+        // Appointments are signed with the user key, as teos expects.
+        let signature = match cryptography::sign(&appointment.to_vec(), &self.user_sk) {
+            Ok(sig) => sig,
+            Err(e) => {
+                log::error!("Cannot sign appointment {}: {e}", appointment.locator);
+                return;
+            }
+        };
+
+        let max_elapsed =
+            Duration::from_secs(MAX_RETRY_ELAPSED_SECS.min(self.cfg.poll_interval_secs.max(10)));
+        let result = retry_with_backoff(max_elapsed, || {
+            send_appointment(
+                self.tower_id,
+                &self.tower_net_addr,
+                &self.proxy,
+                &appointment,
+                &signature,
+            )
+        });
+
+        match result {
+            Ok((_, receipt)) => {
+                log::info!(
+                    "Appointment {} accepted by {}",
+                    appointment.locator,
+                    self.tower_id
+                );
+                if let Err(e) = self
+                    .dbm
+                    .store_appointment_receipt(&appointment.locator.to_string(), &receipt)
+                {
+                    log::error!("Cannot persist appointment receipt: {e}");
+                }
+                let _ = self
+                    .dbm
+                    .set_justice_status(&tracked.commitment_txid, StateStatus::Sent);
+            }
+            Err(RetryError::Misbehaving(proof)) => {
+                log::error!(
+                    "Tower {} misbehaved: receipt signed by {} instead. Proof stored",
+                    self.tower_id,
+                    proof.recovered_id
+                );
+                let _ = self.dbm.store_misbehaving_proof(self.tower_id, &proof);
+                let _ = self
+                    .dbm
+                    .set_justice_status(&tracked.commitment_txid, StateStatus::Invalid);
+            }
+            Err(RetryError::Api(e, code)) => {
+                log::warn!(
+                    "Tower rejected appointment {} ({code}): {e}",
+                    appointment.locator
+                );
+                let _ = self
+                    .dbm
+                    .set_justice_status(&tracked.commitment_txid, StateStatus::Invalid);
+            }
+            Err(RetryError::Unreachable) => {
+                // Left as `pending`: retried on the next tick or after a restart.
+                log::warn!(
+                    "Tower unreachable, appointment {} stays pending",
+                    appointment.locator
+                );
+            }
+        }
+    }
+
+    /// A single iteration of the polling loop.
+    pub fn tick(&self) {
+        self.ensure_registered();
+        // Retry leftovers from previous runs first, then process fresh state.
+        self.retry_pending();
+        self.process_exported_states();
+    }
+}

--- a/ldk-watchtower-client/src/proto.rs
+++ b/ldk-watchtower-client/src/proto.rs
@@ -1,0 +1,160 @@
+//! Local protobuf definitions for the ldk-server `WatchtowerStateExport` API.
+//!
+//! These messages mirror the canonical definitions found in
+//! `ldk-server-grpc/src/proto/{api,types}.proto` (branch `feat/watchtower-export`
+//! of `github.com/vincenzopalazzo/ldk-server`). They are defined locally with
+//! `prost` so this crate does not need a git dependency on any ldk-server repo.
+//!
+//! The wire format is what matters: as long as the field numbers and types match,
+//! messages are interoperable with the ones encoded by ldk-server.
+
+/// Path (relative to the server base URL) of the `WatchtowerStateExport` endpoint.
+///
+/// Mirrors `WATCHTOWER_STATE_EXPORT_PATH` in `ldk-server-grpc/src/endpoints.rs`.
+pub const WATCHTOWER_STATE_EXPORT_PATH: &str = "WatchtowerStateExport";
+
+/// Represents a transaction outpoint.
+#[derive(Clone, PartialEq, Eq, prost::Message)]
+pub struct OutPoint {
+    /// The referenced transaction's txid (hex-encoded).
+    #[prost(string, tag = "1")]
+    pub txid: String,
+    /// The index of the referenced output in the transaction's vout.
+    #[prost(uint32, tag = "2")]
+    pub vout: u32,
+}
+
+/// A justice (penalty) transaction claiming the `to_local` output of a counterparty
+/// commitment transaction via the revocation path.
+#[derive(Clone, PartialEq, Eq, prost::Message)]
+pub struct JusticeTransaction {
+    /// The txid (hex-encoded) of the counterparty commitment transaction this justice
+    /// transaction spends from. This is also the source of the watchtower locator
+    /// (the first 16 bytes of the txid).
+    #[prost(string, tag = "1")]
+    pub commitment_txid: String,
+    /// The commitment number of the counterparty commitment transaction.
+    #[prost(uint64, tag = "2")]
+    pub commitment_number: u64,
+    /// The value, in satoshis, of the `to_local` output being claimed.
+    #[prost(uint64, tag = "3")]
+    pub to_local_value_sats: u64,
+    /// The fully-built justice transaction, consensus-serialized.
+    ///
+    /// The transaction is signed iff `signed` is true. In v1 ldk-server exports
+    /// entries with `signed = false` and empty `justice_tx` bytes.
+    #[prost(bytes = "vec", tag = "4")]
+    pub justice_tx: Vec<u8>,
+    /// Whether `justice_tx` is fully signed and ready to be handed to a watchtower.
+    #[prost(bool, tag = "5")]
+    pub signed: bool,
+}
+
+/// The watchtower-relevant state of a single channel, as exported by the
+/// `WatchtowerStateExport` RPC.
+#[derive(Clone, PartialEq, Eq, prost::Message)]
+pub struct WatchtowerChannelState {
+    /// The channel's funding outpoint.
+    #[prost(message, optional, tag = "1")]
+    pub funding_txo: Option<OutPoint>,
+    /// The hex-encoded local `user_channel_id` of this channel.
+    #[prost(string, tag = "2")]
+    pub user_channel_id: String,
+    /// The channel ID (hex-encoded).
+    #[prost(string, tag = "3")]
+    pub channel_id: String,
+    /// The node ID of the channel's remote counterparty.
+    #[prost(string, tag = "4")]
+    pub counterparty_node_id: String,
+    /// The `to_self_delay` (in blocks) encumbering the counterparty's `to_local` output.
+    #[prost(uint32, tag = "5")]
+    pub to_self_delay: u32,
+    /// The justice transactions for the latest known counterparty commitment state(s).
+    #[prost(message, repeated, tag = "6")]
+    pub justice_transactions: Vec<JusticeTransaction>,
+}
+
+/// Requests an export of the per-channel watchtower state.
+#[derive(Clone, PartialEq, Eq, prost::Message)]
+pub struct WatchtowerStateExportRequest {
+    /// If set, only the state of the channel with this hex-encoded `user_channel_id`
+    /// is exported. Otherwise the state of all channels is exported.
+    #[prost(string, optional, tag = "1")]
+    pub user_channel_id: Option<String>,
+}
+
+/// The response for the `WatchtowerStateExport` RPC.
+#[derive(Clone, PartialEq, Eq, prost::Message)]
+pub struct WatchtowerStateExportResponse {
+    /// The exported watchtower state, one entry per channel.
+    #[prost(message, repeated, tag = "1")]
+    pub channel_states: Vec<WatchtowerChannelState>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[test]
+    fn test_state_export_response_protobuf_roundtrip() {
+        let response = WatchtowerStateExportResponse {
+            channel_states: vec![WatchtowerChannelState {
+                funding_txo: Some(OutPoint {
+                    txid: "d6ac4a5e61657c4c604dcde855a1db74ec6b3e54f32695d72c5e11c7761ea1b4"
+                        .to_owned(),
+                    vout: 0,
+                }),
+                user_channel_id: "aabbccdd".to_owned(),
+                channel_id: "11223344".to_owned(),
+                counterparty_node_id:
+                    "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798".to_owned(),
+                to_self_delay: 144,
+                justice_transactions: vec![
+                    // A signed entry, ready to be turned into an appointment.
+                    JusticeTransaction {
+                        commitment_txid:
+                            "d6ac4a5e61657c4c604dcde855a1db74ec6b3e54f32695d72c5e11c7761ea1b4"
+                                .to_owned(),
+                        commitment_number: 42,
+                        to_local_value_sats: 100_000,
+                        justice_tx: vec![0xde, 0xad, 0xbe, 0xef],
+                        signed: true,
+                    },
+                    // A v1-style unsigned entry with empty justice tx bytes.
+                    JusticeTransaction {
+                        commitment_txid:
+                            "0000000000000000000000000000000000000000000000000000000000000001"
+                                .to_owned(),
+                        commitment_number: 41,
+                        to_local_value_sats: 99_000,
+                        justice_tx: Vec::new(),
+                        signed: false,
+                    },
+                ],
+            }],
+        };
+
+        let encoded = response.encode_to_vec();
+        let decoded = WatchtowerStateExportResponse::decode(encoded.as_slice()).unwrap();
+        assert_eq!(response, decoded);
+    }
+
+    #[test]
+    fn test_state_export_request_protobuf_roundtrip() {
+        for req in [
+            WatchtowerStateExportRequest {
+                user_channel_id: None,
+            },
+            WatchtowerStateExportRequest {
+                user_channel_id: Some("aabbccdd".to_owned()),
+            },
+        ] {
+            let encoded = req.encode_to_vec();
+            assert_eq!(
+                WatchtowerStateExportRequest::decode(encoded.as_slice()).unwrap(),
+                req
+            );
+        }
+    }
+}

--- a/ldk-watchtower-client/src/retrier.rs
+++ b/ldk-watchtower-client/src/retrier.rs
@@ -1,0 +1,76 @@
+//! Bounded retry with exponential backoff for tower interactions.
+//!
+//! A simplified, blocking take on `watchtower-plugin/src/retrier.rs`: transient
+//! (connection) errors are retried with exponential backoff within a bounded
+//! elapsed time, while permanent errors (tower API rejections, misbehavior) are
+//! surfaced immediately. Cross-restart durability is not handled here: the
+//! SQLite database is the persistent retry queue (see `dbm.rs`).
+
+use std::time::Duration;
+
+use backoff::{Error as BackoffError, ExponentialBackoff};
+
+use crate::tower::{AddAppointmentError, RequestError};
+
+/// Errors surfaced by the retry logic once it gives up (or immediately, for
+/// permanent failures).
+#[derive(Debug)]
+pub enum RetryError {
+    /// The tower could not be reached within the retry budget.
+    Unreachable,
+    /// The tower rejected the request (permanent API error).
+    Api(String, u8),
+    /// The tower signed a receipt with a key not matching its tower id.
+    Misbehaving(crate::tower::MisbehaviorProof),
+}
+
+impl std::fmt::Display for RetryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RetryError::Unreachable => write!(f, "tower cannot be reached"),
+            RetryError::Api(e, code) => write!(f, "tower API error ({code}): {e}"),
+            RetryError::Misbehaving(_) => write!(f, "tower misbehaved"),
+        }
+    }
+}
+
+fn classify(e: AddAppointmentError) -> BackoffError<RetryError> {
+    match e {
+        AddAppointmentError::RequestError(RequestError::ConnectionError(_)) => {
+            BackoffError::transient(RetryError::Unreachable)
+        }
+        AddAppointmentError::RequestError(e) => {
+            log::warn!("Unexpected error interacting with the tower: {e}. Retrying");
+            BackoffError::transient(RetryError::Unreachable)
+        }
+        AddAppointmentError::ApiError(e) => {
+            BackoffError::permanent(RetryError::Api(e.error, e.error_code))
+        }
+        AddAppointmentError::SignatureError(proof) => {
+            BackoffError::permanent(RetryError::Misbehaving(proof))
+        }
+    }
+}
+
+/// Retries `op` with exponential backoff until it succeeds, fails permanently, or
+/// `max_elapsed` has passed.
+pub fn retry_with_backoff<T>(
+    max_elapsed: Duration,
+    mut op: impl FnMut() -> Result<T, AddAppointmentError>,
+) -> Result<T, RetryError> {
+    let backoff = ExponentialBackoff {
+        initial_interval: Duration::from_secs(1),
+        max_interval: Duration::from_secs(30),
+        max_elapsed_time: Some(max_elapsed),
+        ..Default::default()
+    };
+
+    backoff::retry_notify(
+        backoff,
+        || op().map_err(classify),
+        |e, next: Duration| log::info!("{e}. Retrying in {}s", next.as_secs()),
+    )
+    .map_err(|e| match e {
+        BackoffError::Permanent(e) | BackoffError::Transient { err: e, .. } => e,
+    })
+}

--- a/ldk-watchtower-client/src/tower.rs
+++ b/ldk-watchtower-client/src/tower.rs
@@ -1,0 +1,264 @@
+//! Blocking HTTP(S) client for the teos (Eye of Satoshi) tower API.
+//!
+//! This mirrors `watchtower-plugin/src/net/http.rs`, adapted to a blocking
+//! `reqwest` client. Towers behind onion addresses are reached through a local
+//! Tor SOCKS5 proxy (`socks5h://`); onion addresses without a proxy are refused.
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use teos_common::appointment::{Appointment, Locator};
+use teos_common::cryptography;
+use teos_common::net::http::Endpoint;
+use teos_common::net::NetAddr;
+use teos_common::protos as common_msgs;
+use teos_common::receipts::{AppointmentReceipt, RegistrationReceipt};
+use teos_common::{TowerId, UserId};
+
+/// SOCKS5 proxy information used to reach (onion) towers.
+#[derive(Clone, Debug)]
+pub struct ProxyInfo {
+    /// The proxy address in `host:port` form (e.g. `127.0.0.1:9050`).
+    address: String,
+}
+
+impl ProxyInfo {
+    pub fn new(address: String) -> Self {
+        ProxyInfo { address }
+    }
+
+    pub fn get_socks_addr(&self) -> String {
+        format!("socks5h://{}", self.address)
+    }
+}
+
+/// Proof that a tower has misbehaved: the returned appointment receipt was signed
+/// by a key that does not match the tower id we were given.
+#[derive(Clone, Serialize, Debug)]
+pub struct MisbehaviorProof {
+    #[serde(with = "hex::serde")]
+    pub locator: Locator,
+    pub appointment_receipt: AppointmentReceipt,
+    pub recovered_id: TowerId,
+}
+
+impl MisbehaviorProof {
+    pub fn new(
+        locator: Locator,
+        appointment_receipt: AppointmentReceipt,
+        recovered_id: TowerId,
+    ) -> Self {
+        Self {
+            locator,
+            appointment_receipt,
+            recovered_id,
+        }
+    }
+}
+
+/// Represents a generic tower API response.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum ApiResponse<T> {
+    Response(T),
+    Error(ApiError),
+}
+
+/// API errors that can be received when interacting with the tower.
+/// Error codes match `teos_common::errors`.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ApiError {
+    pub error: String,
+    pub error_code: u8,
+}
+
+/// Errors related to requests sent to the tower.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RequestError {
+    ConnectionError(String),
+    DeserializeError(String),
+    Unexpected(String),
+}
+
+impl RequestError {
+    pub fn is_connection(&self) -> bool {
+        matches!(self, RequestError::ConnectionError(_))
+    }
+}
+
+impl std::fmt::Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestError::ConnectionError(e) => write!(f, "connection error: {e}"),
+            RequestError::DeserializeError(e) => write!(f, "deserialize error: {e}"),
+            RequestError::Unexpected(e) => write!(f, "unexpected error: {e}"),
+        }
+    }
+}
+
+/// Errors related to the `add_appointment` requests to the tower.
+#[derive(Debug)]
+pub enum AddAppointmentError {
+    RequestError(RequestError),
+    ApiError(ApiError),
+    SignatureError(MisbehaviorProof),
+}
+
+impl From<RequestError> for AddAppointmentError {
+    fn from(r: RequestError) -> Self {
+        AddAppointmentError::RequestError(r)
+    }
+}
+
+impl std::fmt::Display for AddAppointmentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddAppointmentError::RequestError(e) => write!(f, "{e}"),
+            AddAppointmentError::ApiError(e) => {
+                write!(f, "tower API error ({}): {}", e.error_code, e.error)
+            }
+            AddAppointmentError::SignatureError(_) => write!(
+                f,
+                "tower misbehaved: receipt signature does not match tower id"
+            ),
+        }
+    }
+}
+
+/// Builds a reqwest client honoring the Tor proxy rules: requests to onion
+/// addresses go through the proxy; onion addresses without a proxy are refused.
+fn build_client(
+    net_addr: &NetAddr,
+    proxy: &Option<ProxyInfo>,
+) -> Result<reqwest::blocking::Client, RequestError> {
+    match proxy {
+        Some(proxy) if net_addr.is_onion() => reqwest::blocking::Client::builder()
+            .proxy(
+                reqwest::Proxy::http(proxy.get_socks_addr())
+                    .map_err(|e| RequestError::ConnectionError(format!("{e}")))?,
+            )
+            .build()
+            .map_err(|e| RequestError::ConnectionError(format!("{e}"))),
+        None if net_addr.is_onion() => Err(RequestError::ConnectionError(
+            "Cannot connect to an onion address without a proxy".to_owned(),
+        )),
+        _ => Ok(reqwest::blocking::Client::new()),
+    }
+}
+
+/// Sends a protobuf-typed (JSON-serialized) POST request to a tower endpoint.
+pub fn post_request<S: Serialize>(
+    tower_net_addr: &NetAddr,
+    endpoint: Endpoint,
+    data: &S,
+    proxy: &Option<ProxyInfo>,
+) -> Result<reqwest::blocking::Response, RequestError> {
+    let client = build_client(tower_net_addr, proxy)?;
+    client
+        .post(format!("{}{}", tower_net_addr.net_addr(), endpoint.path()))
+        .json(data)
+        .send()
+        .map_err(|e| {
+            log::debug!("An error occurred when sending data to the tower: {e}");
+            if e.is_connect() || e.is_timeout() {
+                RequestError::ConnectionError(
+                    "Cannot connect to the tower. Connection refused".to_owned(),
+                )
+            } else {
+                RequestError::Unexpected(
+                    "Unexpected error occurred (see logs for more info)".to_owned(),
+                )
+            }
+        })
+}
+
+/// Generic function to process the response of a given post request.
+pub fn process_post_response<T: DeserializeOwned>(
+    post_request: Result<reqwest::blocking::Response, RequestError>,
+) -> Result<T, RequestError> {
+    match post_request {
+        Ok(r) => r.json().map_err(|e| {
+            RequestError::DeserializeError(format!("Unexpected response body. Error: {e}"))
+        }),
+        Err(e) => Err(e),
+    }
+}
+
+/// Handles the logic of interacting with the `register` endpoint of the tower.
+pub fn register(
+    tower_id: TowerId,
+    user_id: UserId,
+    tower_net_addr: &NetAddr,
+    proxy: &Option<ProxyInfo>,
+) -> Result<RegistrationReceipt, RequestError> {
+    log::info!("Registering with the Eye of Satoshi (tower_id={tower_id})");
+    process_post_response(post_request(
+        tower_net_addr,
+        Endpoint::Register,
+        &common_msgs::RegisterRequest {
+            user_id: user_id.to_vec(),
+        },
+        proxy,
+    ))
+    .map(|r: common_msgs::RegisterResponse| {
+        RegistrationReceipt::with_signature(
+            user_id,
+            r.available_slots,
+            r.subscription_start,
+            r.subscription_expiry,
+            r.subscription_signature,
+        )
+    })
+}
+
+/// Handles the logic of interacting with the `add_appointment` endpoint of the tower.
+///
+/// On a successful response the receipt signature is verified against the given
+/// tower id; a mismatch yields a [MisbehaviorProof].
+pub fn send_appointment(
+    tower_id: TowerId,
+    tower_net_addr: &NetAddr,
+    proxy: &Option<ProxyInfo>,
+    appointment: &Appointment,
+    signature: &str,
+) -> Result<(common_msgs::AddAppointmentResponse, AppointmentReceipt), AddAppointmentError> {
+    log::debug!(
+        "Sending appointment {} to tower {tower_id}",
+        appointment.locator
+    );
+    let request_data = common_msgs::AddAppointmentRequest {
+        appointment: Some(appointment.clone().into()),
+        signature: signature.to_owned(),
+    };
+
+    match process_post_response(post_request(
+        tower_net_addr,
+        Endpoint::AddAppointment,
+        &request_data,
+        proxy,
+    ))? {
+        ApiResponse::Response::<common_msgs::AddAppointmentResponse>(r) => {
+            let receipt = AppointmentReceipt::with_signature(
+                signature.to_owned(),
+                r.start_block,
+                r.signature.clone(),
+            );
+            let recovered_id = TowerId(
+                cryptography::recover_pk(&receipt.to_vec(), &receipt.signature().unwrap()).unwrap(),
+            );
+            if recovered_id == tower_id {
+                log::debug!(
+                    "Appointment accepted and signed by {tower_id} (start block: {})",
+                    r.start_block
+                );
+                Ok((r, receipt))
+            } else {
+                Err(AddAppointmentError::SignatureError(MisbehaviorProof::new(
+                    appointment.locator,
+                    receipt,
+                    recovered_id,
+                )))
+            }
+        }
+        ApiResponse::Error(e) => Err(AddAppointmentError::ApiError(e)),
+    }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.81"


### PR DESCRIPTION
## Summary
- New workspace crate `ldk-watchtower-client` (~1.8k LOC): the ldk-server analogue of the CLN watchtower-plugin - polls an ldk-server node's `WatchtowerStateExport` endpoint and ships appointments to a teos tower (Tor via `socks5h://` when the tower address is onion)
- Self-contained: local prost defs of the export messages (field numbers match the canonical ldk-server proto), zero new crates beyond the workspace lock, no git deps on ldk-server repos
- Full pipeline: tower registration with persisted receipt -> poll/track per commitment txid -> build `Appointment` (locator = txid[..16], ChaCha20-Poly1305 blob keyed by sha256(dispute_txid)) -> sign + send with bounded backoff -> verify receipt signature, persist `MisbehaviorProof` on mismatch
- SQLite-backed pending queue (`seen -> pending -> sent/invalid`) survives restarts; v1 skips `signed=false`/empty entries but tracks their txids so the transition to signed entries is detected as new state
- Config mirrors teos: structopt CLI + optional TOML (`--ldk-server-url`, `--api-key` (HMAC `x-auth` header as the server expects), `--tower-id`, `--tower-net-addr`, `--tor-proxy`, `--data-dir`, `--poll-interval-secs`, repeatable `--watch-channel`)

## Test plan
- 9 unit tests on the pinned 1.81 toolchain: encrypt/decrypt round-trip against the teos test vector, locator derivation byte-order, protobuf round-trip incl. v1 unsigned entries, skip/filter logic, DBM state transitions (`seen`->`pending`, no downgrade from `sent`), HMAC determinism
- No network tests by design; integration against a live tower + ldk-server is follow-up

Notes: depends on the (draft) ldk-server export endpoint (lightningdevkit/ldk-server#254) and ldk-node watchtower APIs (lightningdevkit/ldk-node#1031). Adds `rust-toolchain.toml` pinning 1.81 (was absent). Bumps `async-stream` 0.3.2->0.3.6 in the lockfile: the pinned version fails to compile on rustc >=1.76 - pre-existing workspace breakage.
