### PR TITLE
Make the Tor control host configurable

### DIFF
--- a/teos/src/api/tor.rs
+++ b/teos/src/api/tor.rs
@@ -12,6 +12,7 @@ use triggered::{Listener, Trigger};
 pub struct TorAPI {
     sk: TorSecretKeyV3,
     api_endpoint: SocketAddr,
+    tor_control_host: String,
     onion_port: u16,
     tor_control_port: u16,
 }
@@ -19,6 +20,7 @@ pub struct TorAPI {
 impl TorAPI {
     pub async fn new(
         api_endpoint: SocketAddr,
+        tor_control_host: String,
         onion_port: u16,
         tor_control_port: u16,
         path: PathBuf,
@@ -35,6 +37,7 @@ impl TorAPI {
         Self {
             sk: key,
             api_endpoint,
+            tor_control_host,
             onion_port,
             tor_control_port,
         }
@@ -68,7 +71,7 @@ impl TorAPI {
 
     /// Tries to connect to the Tor control port
     async fn connect_tor_cp(&self) -> Result<TcpStream, Error> {
-        let sock = TcpStream::connect(format!("127.0.0.1:{}", self.tor_control_port))
+        let sock = TcpStream::connect(format!("{}:{}", self.tor_control_host, self.tor_control_port))
             .await
             .map_err(|_| {
                 Error::new(
@@ -194,6 +197,7 @@ mod tests {
         let tmp_path = TempDir::new(&format!("data_dir_{}", get_random_user_id())).unwrap();
         let tor_api = TorAPI::new(
             "127.0.1.1:9814".parse().unwrap(),
+            "127.0.0.1".into(),
             9814,
             wrong_cp,
             tmp_path.path().into(),

--- a/teos/src/conf_template.toml
+++ b/teos/src/conf_template.toml
@@ -1,6 +1,7 @@
 # API
 api_bind = "127.0.0.1"
 api_port = 9814
+tor_control_host = "127.0.0.1"
 tor_control_port = 9051
 onion_hidden_service_port = 9814
 tor_support = false

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -120,6 +120,10 @@ pub struct Opt {
     #[structopt(long)]
     pub tor_control_port: Option<u16>,
 
+    /// Tor control host [default: 127.0.0.1]
+    #[structopt(long)]
+    pub tor_control_host: Option<String>,
+
     /// Port for the onion hidden service to listen on [default: 9814]
     #[structopt(long)]
     pub onion_hidden_service_port: Option<u16>,
@@ -169,6 +173,7 @@ pub struct Config {
 
     // Tor
     pub tor_support: bool,
+    pub tor_control_host: String,
     pub tor_control_port: u16,
     pub onion_hidden_service_port: u16,
 }
@@ -226,6 +231,9 @@ impl Config {
         }
         if options.tor_control_port.is_some() {
             self.tor_control_port = options.tor_control_port.unwrap();
+        }
+        if options.tor_control_host.is_some() {
+            self.tor_control_host = options.tor_control_host.unwrap();
         }
         if options.onion_hidden_service_port.is_some() {
             self.onion_hidden_service_port = options.onion_hidden_service_port.unwrap();
@@ -318,6 +326,7 @@ impl Default for Config {
             api_bind: "127.0.0.1".into(),
             api_port: 9814,
             tor_support: false,
+            tor_control_host: "127.0.0.1".into(),
             tor_control_port: 9051,
             onion_hidden_service_port: 9814,
             rpc_bind: "127.0.0.1".into(),
@@ -354,6 +363,7 @@ mod tests {
                 api_bind: None,
                 api_port: None,
                 tor_support: false,
+                tor_control_host: None,
                 tor_control_port: None,
                 onion_hidden_service_port: None,
                 rpc_bind: None,

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -344,6 +344,7 @@ async fn main() {
     let tor_api = if conf.tor_support {
         let tor_api = TorAPI::new(
             http_api_addr,
+            conf.tor_control_host,
             conf.onion_hidden_service_port,
             conf.tor_control_port,
             path_network,


### PR DESCRIPTION
### What

`TorAPI::connect_tor_cp` connects to the Tor control port at a hardcoded
`127.0.0.1`. This adds a `tor_control_host` option (CLI `--tor-control-host`,
config key, `conf_template.toml` entry) that defaults to `127.0.0.1`, so the
default behaviour is unchanged.

### Why

When `teosd` runs in its own container (or on a different host from Tor), the
control port is not on loopback. Today that requires patching the source; with
this change it is a config value, consistent with the existing
`tor_control_port` / `rpc_connect` options.

### Changes

- `teos/src/api/tor.rs`: `TorAPI` carries `tor_control_host`; `connect_tor_cp`
  uses `{host}:{port}`. Existing test updated for the new constructor arg.
- `teos/src/config.rs`: `tor_control_host` on `Opt` and `Config`, merged like
  the sibling Tor options, `Default` = `"127.0.0.1"`.
- `teos/src/main.rs`: pass `conf.tor_control_host` into `TorAPI::new`.
- `teos/src/conf_template.toml`: document the key.